### PR TITLE
Keep line-breaks in descriptions

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -40,7 +40,7 @@ def get_data(filepath):
             if 'author' not in data:
                 author = re.match(re_author, line)
                 if author:
-                    data['author'] = author.group(2)
+                    data['author'] = re.sub(r'([^,])[ ]', r'\1&nbsp;', author.group(2))
 
             if 'description' not in data:
                 if re.match(re_desc_start, line):

--- a/generate.py
+++ b/generate.py
@@ -47,7 +47,7 @@ def get_data(filepath):
                     desc_flag = True
                 elif re.match(re_desc_end, line):
                     desc_flag = False
-                    desc = re.match(re_desc, re.sub(r'[\\\n]', '', "".join(desc_lines)))
+                    desc = re.match(re_desc, re.sub(r'[\\\n]', '', "\r".join(map(lambda s: s.strip(), desc_lines))))
                     if desc:
                         data['description'] = desc.group(2)
 


### PR DESCRIPTION
Some descriptions contain &lt;pre&gt; sections - so we need to keep the line breaks in descriptions so that &lt;pre&gt; sections display correctly.

I have tested that the JSON is created as expected, but cannot test that the JSON will display in the wiki as expected.