### PR TITLE
Update addrelease.py

### DIFF
--- a/plugins/addrelease/addrelease.py
+++ b/plugins/addrelease/addrelease.py
@@ -6,7 +6,7 @@ PLUGIN_DESCRIPTION = "Adds a plugin context menu option to clusters and single\
  files to help you quickly add them as releases or standalone recordings to\
  the MusicBrainz database via the website by pre-populating artists,\
  track names and times."
-PLUGIN_VERSION = "0.5"
+PLUGIN_VERSION = "0.6"
 PLUGIN_API_VERSIONS = ["1.0.0"]
 
 from picard.cluster import Cluster
@@ -89,10 +89,13 @@ class AddObjectAsEntity(BaseAction):
 
     def callback(self, objs):
         objdata = self.check_object(objs, self.objtype)
-        if objdata:
-            self.set_form_values(objdata)
-            html_file = self.generate_html_file(self.form_values)
-            self.open_html_file(html_file)
+        try:
+            if objdata:
+                self.set_form_values(objdata)
+                html_file = self.generate_html_file(self.form_values)
+                self.open_html_file(html_file)
+        finally:
+            self.form_values.clear()
 
 
 class AddClusterAsRelease(AddObjectAsEntity):


### PR DESCRIPTION
The this includes only one important change:

Reset self.form_values after generating the HTML file

Otherwise, first adding a release with n track and subsequently adding a
release with n-x track would actually add a release with n tracks again
where tracks 1 to n-x are from the second release and tracks n-1+x to n
are from the first release.