### PR TITLE
PICARD-747: use new QFileDialog.getSaveFileNameAndFilter()

### DIFF
--- a/plugins/cuesheet/cuesheet.py
+++ b/plugins/cuesheet/cuesheet.py
@@ -3,7 +3,7 @@
 PLUGIN_NAME = u"Generate Cuesheet"
 PLUGIN_AUTHOR = u"Lukáš Lalinský"
 PLUGIN_DESCRIPTION = "Generate cuesheet (.cue file) from an album."
-PLUGIN_VERSION = "0.1"
+PLUGIN_VERSION = "0.2"
 PLUGIN_API_VERSIONS = ["0.10", "0.15"]
 
 

--- a/plugins/cuesheet/cuesheet.py
+++ b/plugins/cuesheet/cuesheet.py
@@ -148,8 +148,7 @@ class GenerateCuesheet(BaseAction):
         album = objs[0]
         current_directory = self.config.persist["current_directory"] or QtCore.QDir.homePath()
         current_directory = find_existing_path(unicode(current_directory))
-        selected_format = QtCore.QString()
-        filename = QtGui.QFileDialog.getSaveFileName(None, "", current_directory, "Cuesheet (*.cue)", selected_format)
+        filename, selected_format = QtGui.QFileDialog.getSaveFileNameAndFilter(None, "", current_directory, "Cuesheet (*.cue)")
         if filename:
             filename = unicode(filename)
             cuesheet = Cuesheet(filename)


### PR DESCRIPTION
It was broken by the move to PyQt api version 2, QString cannot be used.
Instead of a mutable string parameter, new method returns a tuple.

It fixes:
selected_format = QtCore.QString()
AttributeError: 'module' object has no attribute 'QString'

http://tickets.musicbrainz.org/browse/PICARD-747