### PR TITLE
Improve plugin metadata parser and simplify generate.py

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -58,7 +58,6 @@ def build_json():
         else:
             print("Added: " + dirname)
             data['files'] = files
-            data['downloads'] = 0
             plugins[dirname] = data
 
     with open(plugin_file, "w") as out_file:

--- a/generate.py
+++ b/generate.py
@@ -19,12 +19,7 @@ def build_json():
     Traverse the plugins directory to generate json data.
     """
 
-    # Read the existing data
-    if os.path.isfile(plugin_file):
-        with open(plugin_file, "r") as in_file:
-            plugins = json.load(in_file)["plugins"]
-    else:
-        plugins = {}
+    plugins = {}
 
     # All top level directories in plugin_dir are plugins
     for dirname in next(os.walk(plugin_dir))[1]:
@@ -49,13 +44,7 @@ def build_json():
                     if ext in ['.py'] and not data:
                         data = get_plugin_data(os.path.join(plugin_dir, dirname, filename))
 
-        if dirname in plugins:
-            print("Updated: " + dirname)
-            if data:
-                for key, value in data.items():
-                    plugins[dirname][key] = value
-            plugins[dirname]["files"] = files
-        else:
+        if files and data:
             print("Added: " + dirname)
             data['files'] = files
             plugins[dirname] = data

--- a/get_plugin_data.py
+++ b/get_plugin_data.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import ast
+
+known_data = [
+    'PLUGIN_NAME',
+    'PLUGIN_AUTHOR',
+    'PLUGIN_VERSION',
+    'PLUGIN_API_VERSIONS',
+    'PLUGIN_LICENSE',
+    'PLUGIN_LICENSE_URL',
+    'PLUGIN_DESCRIPTION',
+]
+
+
+def get_plugin_data(filepath):
+    """Parse a python file and return a dict with plugin metadata"""
+    data = {}
+    with open(filepath, 'r') as plugin_file:
+        source = plugin_file.read()
+        try:
+            root = ast.parse(source, filepath)
+        except Exception as e:
+            print "Cannot parse " + filepath
+            raise e
+        for node in ast.iter_child_nodes(root):
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                target = node.targets[0]
+                if (isinstance(target, ast.Name)
+                    and isinstance(target.ctx, ast.Store)
+                    and target.id in known_data):
+                    name = target.id.replace('PLUGIN_', '', 1).lower()
+                    if name == 'api_versions':  # wtf
+                        name = 'api_version'
+                    if name not in data:
+                        try:
+                            data[name] = ast.literal_eval(node.value)
+                            if isinstance(data[name], list):
+                                data[name] = ", ".join(data[name])
+                        except ValueError as e:
+                            print filepath + ':' + ast.dump(node)
+                            pass
+        return data

--- a/get_plugin_data.py
+++ b/get_plugin_data.py
@@ -30,8 +30,6 @@ def get_plugin_data(filepath):
                     and isinstance(target.ctx, ast.Store)
                     and target.id in known_data):
                     name = target.id.replace('PLUGIN_', '', 1).lower()
-                    if name == 'api_versions':  # wtf
-                        name = 'api_version'
                     if name not in data:
                         try:
                             data[name] = ast.literal_eval(node.value)

--- a/get_plugin_data.py
+++ b/get_plugin_data.py
@@ -33,8 +33,6 @@ def get_plugin_data(filepath):
                     if name not in data:
                         try:
                             data[name] = ast.literal_eval(node.value)
-                            if isinstance(data[name], list):
-                                data[name] = ", ".join(data[name])
                         except ValueError as e:
                             print filepath + ':' + ast.dump(node)
                             pass

--- a/plugins/albumartist_website/albumartist_website.py
+++ b/plugins/albumartist_website/albumartist_website.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-PLUGIN_NAME = _(u'Album Artist Website')
+PLUGIN_NAME = u'Album Artist Website'
 PLUGIN_AUTHOR = u'Sophist'
 PLUGIN_DESCRIPTION = u'''Add's the album artist(s) Official Homepage(s)
 (if they are defined in the MusicBrainz database).'''

--- a/plugins/standardise_performers/standardise_performers.py
+++ b/plugins/standardise_performers/standardise_performers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-PLUGIN_NAME = _(u'Standardise Performers')
+PLUGIN_NAME = u'Standardise Performers'
 PLUGIN_AUTHOR = u'Sophist'
 PLUGIN_DESCRIPTION = u'''Splits multi-instrument performer tags into single
 instruments and combines names so e.g. (from 10cc by 10cc track 1):

--- a/test.py
+++ b/test.py
@@ -72,7 +72,6 @@ class GenerateTestCase(unittest.TestCase):
             self.assertIsInstance(data['name'], basestring)
             self.assertIsInstance(data['api_version'], basestring)
             self.assertIsInstance(data['author'], basestring)
-            self.assertIsInstance(data['downloads'], int)
             self.assertIsInstance(data['description'], basestring)
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -70,7 +70,7 @@ class GenerateTestCase(unittest.TestCase):
         # All plugins should contain all required fields
         for module_name, data in plugin_json.items():
             self.assertIsInstance(data['name'], basestring)
-            self.assertIsInstance(data['api_version'], basestring)
+            self.assertIsInstance(data['api_versions'], basestring)
             self.assertIsInstance(data['author'], basestring)
             self.assertIsInstance(data['description'], basestring)
 

--- a/test.py
+++ b/test.py
@@ -70,7 +70,7 @@ class GenerateTestCase(unittest.TestCase):
         # All plugins should contain all required fields
         for module_name, data in plugin_json.items():
             self.assertIsInstance(data['name'], basestring)
-            self.assertIsInstance(data['api_versions'], basestring)
+            self.assertIsInstance(data['api_versions'], list)
             self.assertIsInstance(data['author'], basestring)
             self.assertIsInstance(data['description'], basestring)
 


### PR DESCRIPTION
Replace regex-based parser by one based on ast
Remove extra code related to the historical 'downloads' counter

It fixes https://github.com/musicbrainz/picard-plugins/issues/30


