### PR TITLE
FanartTv plugin runs even when it's disabled

### DIFF
--- a/plugins/fanarttv/__init__.py
+++ b/plugins/fanarttv/__init__.py
@@ -70,6 +70,7 @@ class CoverArtProviderFanartTv(CoverArtProvider):
 
     def enabled(self):
         return self._client_key != "" and \
+            super(CoverArtProviderFanartTv, self).enabled() and \
             not self.coverart.front_image_found
 
     def queue_downloads(self):

--- a/plugins/fanarttv/__init__.py
+++ b/plugins/fanarttv/__init__.py
@@ -20,7 +20,7 @@
 PLUGIN_NAME = u'fanart.tv cover art'
 PLUGIN_AUTHOR = u'Philipp Wolfer'
 PLUGIN_DESCRIPTION = u'Use cover art from fanart.tv. To use this plugin you have to register a personal API key on https://fanart.tv/get-an-api-key/'
-PLUGIN_VERSION = "0.4"
+PLUGIN_VERSION = "0.5"
 PLUGIN_API_VERSIONS = ["1.4.0"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"


### PR DESCRIPTION
If one has installed and activated fanarttv plugin, but disabled it in cover art settings, picard still fetches the coverart from fanarttv. In my situation,
 
![fanart](https://cloud.githubusercontent.com/assets/7776696/12108653/2faad862-b3a0-11e5-846b-900a5cfba10e.png)

I suppose this can be considered a bug.