### PR TITLE
PICARD-1028: New "Smart Title Case" plugin

### DIFF
--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
+# This is the Smart Title Case plugin for MusicBrainz Picard.
+# Copyright (C) 2017 Sophist.
+#
+# It is based on the Title Case plugin by Javier Kohen
 # Copyright 2007 Javier Kohen
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 PLUGIN_NAME = "Smart Title Case"
 PLUGIN_AUTHOR = u"Sophist based on an earlier plugin by Javier Kohen"

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -39,7 +39,7 @@ artist_tags = [
     ('albumartist', '~albumartists'),
     ('albumartistsort', '~albumartists_sort'),
     ]
-title_re = re.compile(ur'\w[^-,/\s\u2010]*', re.UNICODE)
+title_re = re.compile(ur'\w[^-,/\s\u2010\u2011]*', re.UNICODE)
 
 def match_word(match):
     word = match.group(0)

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
+
 # This is the Smart Title Case plugin for MusicBrainz Picard.
 # Copyright (C) 2017 Sophist.
 #

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+# Copyright 2007 Javier Kohen
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation
+
+PLUGIN_NAME = "Smart Title Case"
+PLUGIN_AUTHOR = u"Sophist based on an earlier plugin by Javier Kohen"
+PLUGIN_DESCRIPTION = """
+Capitalize First Character In Every Word Of Album/Track Title/Artist.<br />
+Leaves words containing embedded uppercase as-is i.e. USA or DoA.<br />
+For Artist/AlbumArtist, title cases only artists not join phrases<br />
+e.g. The Beatles feat. The Who.
+"""
+PLUGIN_VERSION = "0.1"
+PLUGIN_API_VERSIONS = ["1.4.0"]
+PLUGIN_LICENSE = "GPL-3.0"
+PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-3.0.html"
+
+import re, unicodedata
+from picard import log
+from picard.metadata import (
+    register_track_metadata_processor,
+    register_album_metadata_processor,
+)
+
+title_tags = ['title', 'album']
+artist_tags = [
+    ('artist', 'artists'),
+    ('artistsort', '~artists_sort'),
+    ('albumartist', '~albumartists'),
+    ('albumartistsort', '~albumartists_sort'),
+    ]
+title_re = re.compile(r'\S+', re.UNICODE)
+
+def match_word(match):
+    word = match.group(0)
+    if word == word.lower():
+        word = word[0].upper() + word[1:]
+    return word
+
+def string_title_case(string, locale="utf-8"):
+    """Title-case a string using a less destructive method than str.title."""
+    if not string:
+        return u""
+    if not isinstance(string, unicode):
+        string = string.decode(locale)
+    # Replace with normalised unicode string
+    string = unicodedata.normalize("NFKC", string)
+    return title_re.sub(match_word, string)
+
+assert "Make Title" == string_title_case("make title")
+assert "mAkE tItLe" == string_title_case("mAkE tItLe")
+assert "Make's Title's" == string_title_case("make's title's")
+
+def match_phrase(match):
+    phrase = match.group(0)
+    return string_title_case(phrase)
+
+def artist_title_case(text, artists):
+    """
+    Use the array of artists and the joined string
+    to identify artists to make title case
+    and the join strings to leave as-is.
+    """
+    find = u"^(" + ur")(\s+\S+?\s+)(".join((map(re.escape, artists))) + u")(.*$)"
+    replace = "".join([ur"%s\%d" % (string_title_case(a), x*2 + 2) for x, a in enumerate(artists)])
+    result = re.sub(find, replace, text, re.UNICODE)
+    log.debug("SmartTitleCase: %r replaced with %r", text, result)
+    return
+
+assert "The Beatles feat. The Who" == artist_title_case("the beatles feat. the who", ["the beatles", "the who"])
+
+def title_case(tagger, metadata, release, track=None):
+    for name in title_tags:
+        if name in metadata:
+            values = metadata.getall(name)
+            metadata[name] = [string_title_case(v) for v in values]
+    for artist_string, artists_list in artist_tags:
+        if artist_string in metadata and artists_list in metadata:
+            values = metadata.getall(artist_string)
+            artists = metadata.getall(artists_list)
+            metadata[artist_string] = [artist_title_case(x, artists) for x in values]
+
+register_track_metadata_processor(title_case)
+register_album_metadata_processor(title_case)

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -39,7 +39,7 @@ artist_tags = [
     ('albumartist', '~albumartists'),
     ('albumartistsort', '~albumartists_sort'),
     ]
-title_re = re.compile(r'\w[^-,/\s]*', re.UNICODE)
+title_re = re.compile(ur'\w[^-,/\s\u2010]*', re.UNICODE)
 
 def match_word(match):
     word = match.group(0)
@@ -74,13 +74,6 @@ assert "A,B" == string_title_case("a,b")
 assert "A-B" == string_title_case("a-b")
 assert "A/B" == string_title_case("a/b")
 
-# Put this here so that above unit tests can run standalone before getting an import error
-from picard import log
-from picard.metadata import (
-    register_track_metadata_processor,
-    register_album_metadata_processor,
-)
-
 def artist_title_case(text, artists, artists_upper):
     """
     Use the array of artists and the joined string
@@ -97,6 +90,13 @@ assert "The Beatles feat. The Who" == artist_title_case(
                                         ["the beatles", "the who"],
                                         ["The Beatles", "The Who"]
                                         )
+
+# Put this here so that above unit tests can run standalone before getting an import error
+from picard import log
+from picard.metadata import (
+    register_track_metadata_processor,
+    register_album_metadata_processor,
+)
 
 def title_case(tagger, metadata, release, track=None):
     for name in title_tags:

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -20,11 +20,6 @@ PLUGIN_LICENSE = "GPL-3.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-3.0.html"
 
 import re, unicodedata
-from picard import log
-from picard.metadata import (
-    register_track_metadata_processor,
-    register_album_metadata_processor,
-)
 
 title_tags = ['title', 'album']
 artist_tags = [
@@ -33,7 +28,7 @@ artist_tags = [
     ('albumartist', '~albumartists'),
     ('albumartistsort', '~albumartists_sort'),
     ]
-title_re = re.compile(r'\S+', re.UNICODE)
+title_re = re.compile(r'\w\S*', re.UNICODE)
 
 def match_word(match):
     word = match.group(0)
@@ -51,13 +46,21 @@ def string_title_case(string, locale="utf-8"):
     string = unicodedata.normalize("NFKC", string)
     return title_re.sub(match_word, string)
 
-assert "Make Title" == string_title_case("make title")
-assert "mAkE tItLe" == string_title_case("mAkE tItLe")
-assert "Make's Title's" == string_title_case("make's title's")
+assert "Make Title Case" == string_title_case("make title case")
+assert "Already Title Case" == string_title_case("Already Title Case")
+assert "mIxEd cAsE" == string_title_case("mIxEd cAsE")
+assert "A" == string_title_case("a")
+assert "Apostrophe's Apostrophe's" == string_title_case("apostrophe's apostrophe's")
+assert "(Bracketed Text)" == string_title_case("(bracketed text)")
+assert "'Single Quotes'" == string_title_case("'single quotes'")
+assert '"Double Quotes"' == string_title_case('"double quotes"')
 
-def match_phrase(match):
-    phrase = match.group(0)
-    return string_title_case(phrase)
+# Put this here so that above unit tests can run standalone before getting an import error
+from picard import log
+from picard.metadata import (
+    register_track_metadata_processor,
+    register_album_metadata_processor,
+)
 
 def artist_title_case(text, artists):
     """

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -111,17 +111,21 @@ def title_case(tagger, metadata, release, track=None):
             artist = metadata.getall(artist_string)
             artists = metadata.getall(artists_list)
             new_artists = map(string_title_case, artists)
-            new_artist = [artist_title_case(x, artists, new_artists) for x in values]
+            new_artist = [artist_title_case(x, artists, new_artists) for x in artist]
             if artists != new_artists and artist != new_artist:
                 log.debug("SmartTitleCase: %s: %s replaced with %s", artist_string, artist, new_artist)
-                log.debug("SmartTitleCase: %s: %r replaced with %r", artist_list, artists, new_artists)
+                log.debug("SmartTitleCase: %s: %r replaced with %r", artists_list, artists, new_artists)
                 metadata[artist_string] = new_artist
                 metadata[artists_list] = new_artists
             elif artists != new_artists or artist != new_artist:
                 if artists != new_artists:
                     log.warning("SmartTitleCase: %s changed, %s wasn't", artists_list, artist_string)
+                    log.warning("SmartTitleCase: %s: %r changed to %r", artists_list, artists, new_artists)
+                    log.warning("SmartTitleCase: %s: %r unchanged", artist_string, artist)
                 else:
                     log.warning("SmartTitleCase: %s changed, %s wasn't", artist_string, artists_list)
+                    log.warning("SmartTitleCase: %s: %r changed to %r", artist_string, artist, new_artist)
+                    log.warning("SmartTitleCase: %s: %r unchanged", artists_list, artists)
 
 register_track_metadata_processor(title_case)
 register_album_metadata_processor(title_case)

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -73,7 +73,7 @@ def artist_title_case(text, artists):
     to identify artists to make title case
     and the join strings to leave as-is.
     """
-    find = u"^(" + ur")(\s+\S+?\s+)(".join((map(re.escape, artists))) + u")(.*$)"
+    find = u"^(" + ur")(\s+\S+?\s+)(".join((map(re.escape, map(string_cleanup,artists)))) + u")(.*$)"
     replace = "".join([ur"%s\%d" % (string_title_case(a), x*2 + 2) for x, a in enumerate(artists)])
     result = re.sub(find, replace, string_cleanup(text), re.UNICODE)
     if result != text:

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -36,15 +36,20 @@ def match_word(match):
         word = word[0].upper() + word[1:]
     return word
 
-def string_title_case(string, locale="utf-8"):
-    """Title-case a string using a less destructive method than str.title."""
+def string_title_match(match_word, string):
+    return title_re.sub(match_word, string)
+
+def string_cleanup(string, locale="utf-8"):
     if not string:
         return u""
     if not isinstance(string, unicode):
         string = string.decode(locale)
     # Replace with normalised unicode string
-    string = unicodedata.normalize("NFKC", string)
-    return title_re.sub(match_word, string)
+    return unicodedata.normalize("NFKC", string)
+
+def string_title_case(string, locale="utf-8"):
+    """Title-case a string using a less destructive method than str.title."""
+    return string_title_match(match_word, string_cleanup(string, locale))
 
 assert "Make Title Case" == string_title_case("make title case")
 assert "Already Title Case" == string_title_case("Already Title Case")
@@ -70,9 +75,10 @@ def artist_title_case(text, artists):
     """
     find = u"^(" + ur")(\s+\S+?\s+)(".join((map(re.escape, artists))) + u")(.*$)"
     replace = "".join([ur"%s\%d" % (string_title_case(a), x*2 + 2) for x, a in enumerate(artists)])
-    result = re.sub(find, replace, text, re.UNICODE)
-    log.debug("SmartTitleCase: %r replaced with %r", text, result)
-    return
+    result = re.sub(find, replace, string_cleanup(text), re.UNICODE)
+    if result != text:
+        log.debug("SmartTitleCase: %r replaced with %r", text, result)
+    return result
 
 assert "The Beatles feat. The Who" == artist_title_case("the beatles feat. the who", ["the beatles", "the who"])
 


### PR DESCRIPTION
This is an alternative to the existing Title Case plugin.

It makes more tags Title Case and handles artist tags smartly by converting artists to title case whilst leaving joinn phrases as-is.

Resolves https://tickets.metabrainz.org/browse/PICARD-1028