### PR TITLE
AlbumArtist Extension v0.5

### DIFF
--- a/plugins/albumartistextension/albumartistextension.py
+++ b/plugins/albumartistextension/albumartistextension.py
@@ -8,33 +8,22 @@ more detailed information about the album artists.
 <br /><br />
 The information is provided in the following variables:
 <ul>
-<li>_aaeStdAlbumArtists = The standardized version of album artist(s)
-<li>_aaeCredAlbumArtists = The credited version of album artist(s)
-<li>_aaeSortAlbumArtists = The sorted version of album artist(s)
+<li>_aaeStdAlbumArtists = The standardized version of the album artists.
+<li>_aaeCredAlbumArtists = The credited version of the album artists.
+<li>_aaeSortAlbumArtists = The sorted version of the album artists.
+<li>_aaeStdPrimaryAlbumArtist = The standardized version of the first
+    (primary) album artist.
+<li>_aaeCredPrimaryAlbumArtist = The credited version of the first (primary)
+    album artist.
+<li>_aaeSortPrimaryAlbumArtist_n = The sorted version of the first (primary)
+    album artist.
 <li>_aaeAlbumArtistCount = The number of artists comprising the album artist.
-<li>_aaeStdAlbumArtist_n = The standardized version of the album artists,
-    where n is the number of the artist in the list starting at 0.  If there 
-    are two artists in the AlbumArtist tag, then they will be available in 
-    the _aaeStdAlbumArtist_0 and _aaeStdAlbumArtist_1 variables. 
-<li>_aaeCredAlbumArtist_n = The credited version of the album artists,
-    where n is the number of the artist in the list starting at 0.  If there
-    are two artists in the AlbumArtist tag, then they will be available in
-    the _aaeCredAlbumArtist_0 and _aaeCredAlbumArtist_1 variables.
-<li>_aaeSortAlbumArtist_n = The sorted version of the album artists, where
-    n is the number of the artist in the list starting at 0.  If there are
-    two artists in the AlbumArtist tag, then they will be available in the
-    _aaeSortAlbumArtist_0 and _aaeSortAlbumArtist_1 variables.
-<li>_aaeJoinPhrase_n = The phrases used to join the album artists, where n
-    is the number of the phrase in the list starting at 0.  NOTE: This
-    variable will not be provided if there is only one artist in the
-    AlbumArtist tag.  The user should check that _aaeAlbumArtistCount is
-    greater than one before using this variable.
 </ul>
 PLEASE NOTE: Tagger scripts are required to make use of these hidden
 variables.
 '''
 
-PLUGIN_VERSION = "0.3"
+PLUGIN_VERSION = "0.4"
 PLUGIN_API_VERSIONS = ["1.4"]
 PLUGIN_LICENSE = "GPL-2.0 or later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -67,7 +56,6 @@ class AlbumArtistStdName:
                     # Check if there is a 'joinphrase' specified.
                     if 'joinphrase' in ncredit.attribs:
                         tempPhrase = ncredit.joinphrase
-                        jPhrase.append(tempPhrase)
                     # Check if there is a 'name' specified.  This will be the
                     # credited name.
                     if 'name' in ncredit.children:
@@ -82,10 +70,11 @@ class AlbumArtistStdName:
                         if 'name' in ncredit.artist[0].children:
                             tempStdName = ncredit.artist[0].name[0].text
                             stdArtist += tempStdName + tempPhrase
-                            album_metadata["~aaeStdAlbumArtist_%i" % aCount] = tempStdName
                             tCredName = tempCredName if len(tempCredName) > 0 else tempStdName
                             credArtist += tCredName + tempPhrase
-                            album_metadata["~aaeCredAlbumArtist_%i" % aCount] = tCredName
+                            if aCount < 1:
+                                album_metadata["~aaeStdPrimaryAlbumArtist"] = tempStdName
+                                album_metadata["~aaeCredPrimaryAlbumArtist"] = tCredName
                         else:
                             log.error("%s: %r: Missing artist 'name' in XML contents: %s",
                                     PLUGIN_NAME, albumid, releaseXmlNode)
@@ -95,7 +84,8 @@ class AlbumArtistStdName:
                         if 'sort_name' in ncredit.artist[0].children:
                             tempSortName = ncredit.artist[0].sort_name[0].text
                             sortArtist += tempSortName + tempPhrase
-                            album_metadata["~aaeSortAlbumArtist_%i" % aCount] = tempSortName
+                            if aCount < 1:
+                                album_metadata["~aaeSortPrimaryAlbumArtist"] = tempSortName
                         else:
                             log.error("%s: %r: Missing artist 'sort_name' in XML contents: %s",
                                     PLUGIN_NAME, albumid, releaseXmlNode)
@@ -114,11 +104,6 @@ class AlbumArtistStdName:
                 album_metadata["~aaeSortAlbumArtists"] = sortArtist
             if aCount > 0:
                 album_metadata["~aaeAlbumArtistCount"] = aCount
-            # Reset counter
-            aCount = 0
-            for tPhrase in jPhrase:
-                album_metadata["~aaeJoinPhrase_%i" % aCount] = tPhrase
-                aCount += 1
         else:
             log.error("%s: %r: Error reading XML contents: %s",
                       PLUGIN_NAME, albumid, releaseXmlNode)

--- a/plugins/albumartistextension/albumartistextension.py
+++ b/plugins/albumartistextension/albumartistextension.py
@@ -1,0 +1,127 @@
+PLUGIN_NAME = 'AlbumArtist Extension'
+PLUGIN_AUTHOR = 'Bob Swift (rdswift)'
+PLUGIN_DESCRIPTION = '''
+This plugin provides standardized, credited and sorted artist information
+for the album artist.  This is useful when your tagging or renaming scripts
+require both the standardized artist name and the credited artist name, or
+more detailed information about the album artists.
+<br /><br />
+The information is provided in the following variables:
+<ul>
+<li>_aaeStdAlbumArtists = The standardized version of album artist(s)
+<li>_aaeCredAlbumArtists = The credited version of album artist(s)
+<li>_aaeSortAlbumArtists = The sorted version of album artist(s)
+<li>_aaeAlbumArtistCount = The number of artists comprising the album artist.
+<li>_aaeStdAlbumArtist_n = The standardized version of the album artists,
+    where n is the number of the artist in the list starting at 0.  If there 
+    are two artists in the AlbumArtist tag, then they will be available in 
+    the _aaeStdAlbumArtist_0 and _aaeStdAlbumArtist_1 variables. 
+<li>_aaeCredAlbumArtist_n = The credited version of the album artists,
+    where n is the number of the artist in the list starting at 0.  If there
+    are two artists in the AlbumArtist tag, then they will be available in
+    the _aaeCredAlbumArtist_0 and _aaeCredAlbumArtist_1 variables.
+<li>_aaeSortAlbumArtist_n = The sorted version of the album artists, where
+    n is the number of the artist in the list starting at 0.  If there are
+    two artists in the AlbumArtist tag, then they will be available in the
+    _aaeSortAlbumArtist_0 and _aaeSortAlbumArtist_1 variables.
+<li>_aaeJoinPhrase_n = The phrases used to join the album artists, where n
+    is the number of the phrase in the list starting at 0.  NOTE: This
+    variable will not be provided if there is only one artist in the
+    AlbumArtist tag.  The user should check that _aaeAlbumArtistCount is
+    greater than one before using this variable.
+</ul>
+PLEASE NOTE: Tagger scripts are required to make use of these hidden
+variables.
+'''
+
+PLUGIN_VERSION = "0.3"
+PLUGIN_API_VERSIONS = ["1.4"]
+PLUGIN_LICENSE = "GPL-2.0 or later"
+PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
+
+from picard import log
+from picard.metadata import register_album_metadata_processor
+
+class AlbumArtistStdName:
+
+    @staticmethod
+    def add_artist_std_name(album, album_metadata, releaseXmlNode):
+        albumid = releaseXmlNode.id
+        # Test for valid XML node for the release
+        if 'artist_credit' in releaseXmlNode.children:
+            # Initialize variables to default values
+            credArtist = ""
+            stdArtist = ""
+            sortArtist = ""
+            aCount = 0
+            jPhrase = []
+            # The 'name_credit' child should always be there.
+            # This check is to avoid a runtime error if it doesn't exist for some reason.
+            if 'name_credit' in releaseXmlNode.artist_credit[0].children:
+                for ncredit in releaseXmlNode.artist_credit[0].name_credit:
+                    # Initialize temporary variables for each loop.
+                    tempStdName = ""
+                    tempCredName = ""
+                    tempSortName = ""
+                    tempPhrase = ""
+                    # Check if there is a 'joinphrase' specified.
+                    if 'joinphrase' in ncredit.attribs:
+                        tempPhrase = ncredit.joinphrase
+                        jPhrase.append(tempPhrase)
+                    # Check if there is a 'name' specified.  This will be the
+                    # credited name.
+                    if 'name' in ncredit.children:
+                        tempCredName = ncredit.name[0].text
+                    # The 'artist' child should always be there.
+                    # This check is to avoid a runtime error if it doesn't
+                    # exist for some reason.
+                    if 'artist' in ncredit.children:
+                        # The 'name' child should always be there.
+                        # This check is to avoid a runtime error if it
+                        # doesn't exist for some reason.
+                        if 'name' in ncredit.artist[0].children:
+                            tempStdName = ncredit.artist[0].name[0].text
+                            stdArtist += tempStdName + tempPhrase
+                            album_metadata["~aaeStdAlbumArtist_%i" % aCount] = tempStdName
+                            tCredName = tempCredName if len(tempCredName) > 0 else tempStdName
+                            credArtist += tCredName + tempPhrase
+                            album_metadata["~aaeCredAlbumArtist_%i" % aCount] = tCredName
+                        else:
+                            log.error("%s: %r: Missing artist 'name' in XML contents: %s",
+                                    PLUGIN_NAME, albumid, releaseXmlNode)
+                        # The 'sort_name' child should always be there.
+                        # This check is to avoid a runtime error if it
+                        # doesn't exist for some reason.
+                        if 'sort_name' in ncredit.artist[0].children:
+                            tempSortName = ncredit.artist[0].sort_name[0].text
+                            sortArtist += tempSortName + tempPhrase
+                            album_metadata["~aaeSortAlbumArtist_%i" % aCount] = tempSortName
+                        else:
+                            log.error("%s: %r: Missing artist 'sort_name' in XML contents: %s",
+                                    PLUGIN_NAME, albumid, releaseXmlNode)
+                    else:
+                        log.error("%s: %r: Missing 'artist' in XML contents: %s",
+                                PLUGIN_NAME, albumid, releaseXmlNode)
+                    aCount += 1
+                else:
+                    log.error("%s: %r: Missing 'name_credit' in XML contents: %s",
+                            PLUGIN_NAME, albumid, releaseXmlNode)
+            if len(stdArtist) > 0:
+                album_metadata["~aaeStdAlbumArtists"] = stdArtist
+            if len(credArtist) > 0:
+                album_metadata["~aaeCredAlbumArtists"] = credArtist
+            if len(sortArtist) > 0:
+                album_metadata["~aaeSortAlbumArtists"] = sortArtist
+            if aCount > 0:
+                album_metadata["~aaeAlbumArtistCount"] = aCount
+            # Reset counter
+            aCount = 0
+            for tPhrase in jPhrase:
+                album_metadata["~aaeJoinPhrase_%i" % aCount] = tPhrase
+                aCount += 1
+        else:
+            log.error("%s: %r: Error reading XML contents: %s",
+                      PLUGIN_NAME, albumid, releaseXmlNode)
+        return None
+
+register_album_metadata_processor(AlbumArtistStdName().add_artist_std_name)

--- a/plugins/albumartistextension/albumartistextension.py
+++ b/plugins/albumartistextension/albumartistextension.py
@@ -15,7 +15,7 @@ The information is provided in the following variables:
     (primary) album artist.
 <li>_aaeCredPrimaryAlbumArtist = The credited version of the first (primary)
     album artist.
-<li>_aaeSortPrimaryAlbumArtist_n = The sorted version of the first (primary)
+<li>_aaeSortPrimaryAlbumArtist = The sorted version of the first (primary)
     album artist.
 <li>_aaeAlbumArtistCount = The number of artists comprising the album artist.
 </ul>

--- a/plugins/albumartistextension/albumartistextension.py
+++ b/plugins/albumartistextension/albumartistextension.py
@@ -23,13 +23,14 @@ PLEASE NOTE: Tagger scripts are required to make use of these hidden
 variables.
 '''
 
-PLUGIN_VERSION = "0.4"
+PLUGIN_VERSION = "0.5"
 PLUGIN_API_VERSIONS = ["1.4"]
 PLUGIN_LICENSE = "GPL-2.0 or later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
-from picard import log
+from picard import config, log
 from picard.metadata import register_album_metadata_processor
+from picard.plugin import PluginPriority
 
 class AlbumArtistStdName:
 
@@ -43,6 +44,9 @@ class AlbumArtistStdName:
             stdArtist = ""
             sortArtist = ""
             aCount = 0
+            # Get the current lists of _albumartists and _albumartists_sort
+            metaAlbumArtists = dict.get(album_metadata,"~albumartists")
+            metaAlbumArtists_Sort = dict.get(album_metadata,"~albumartists_sort")
             # The 'name_credit' child should always be there.
             # This check is to avoid a runtime error if it doesn't exist for some reason.
             if 'name_credit' in releaseXmlNode.artist_credit[0].children:
@@ -55,10 +59,16 @@ class AlbumArtistStdName:
                     # Check if there is a 'joinphrase' specified.
                     if 'joinphrase' in ncredit.attribs:
                         tempPhrase = ncredit.joinphrase
-                    # Check if there is a 'name' specified.  This will be the
-                    # credited name.
-                    if 'name' in ncredit.children:
-                        tempCredName = ncredit.name[0].text
+                    # Set the credit name from the AlbumArtist list if the
+                    # 'Use standardized artist name' option is not checked
+                    # in Picard, otherwise use the XML information.
+                    if config.setting["standardize_artists"]:
+                        # Check if there is a 'name' specified.  This will be the
+                        # credited name.
+                        if 'name' in ncredit.children:
+                            tempCredName = ncredit.name[0].text
+                    else:
+                        tempCredName = metaAlbumArtists[aCount]
                     # The 'artist' child should always be there.
                     # This check is to avoid a runtime error if it doesn't
                     # exist for some reason.
@@ -67,7 +77,11 @@ class AlbumArtistStdName:
                         # This check is to avoid a runtime error if it
                         # doesn't exist for some reason.
                         if 'name' in ncredit.artist[0].children:
-                            tempStdName = ncredit.artist[0].name[0].text
+                            # Set the standardized name from the  AlbumArtist
+                            # list if the 'Use standardized artist name'
+                            # option is checked in Picard, otherwise use the
+                            # XML information.
+                            tempStdName = metaAlbumArtists[aCount] if config.setting["standardize_artists"] else ncredit.artist[0].name[0].text
                             stdArtist += tempStdName + tempPhrase
                             tCredName = tempCredName if len(tempCredName) > 0 else tempStdName
                             credArtist += tCredName + tempPhrase
@@ -77,17 +91,12 @@ class AlbumArtistStdName:
                         else:
                             log.error("%s: %r: Missing artist 'name' in XML contents: %s",
                                     PLUGIN_NAME, albumid, releaseXmlNode)
-                        # The 'sort_name' child should always be there.
-                        # This check is to avoid a runtime error if it
-                        # doesn't exist for some reason.
-                        if 'sort_name' in ncredit.artist[0].children:
-                            tempSortName = ncredit.artist[0].sort_name[0].text
-                            sortArtist += tempSortName + tempPhrase
-                            if aCount < 1:
-                                album_metadata["~aaeSortPrimaryAlbumArtist"] = tempSortName
-                        else:
-                            log.error("%s: %r: Missing artist 'sort_name' in XML contents: %s",
-                                    PLUGIN_NAME, albumid, releaseXmlNode)
+                        # Get the artist sort name from the
+                        # _albumartists_sort list
+                        tempSortName = metaAlbumArtists_Sort[aCount]
+                        sortArtist += tempSortName + tempPhrase
+                        if aCount < 1:
+                            album_metadata["~aaeSortPrimaryAlbumArtist"] = tempSortName
                     else:
                         log.error("%s: %r: Missing 'artist' in XML contents: %s",
                                 PLUGIN_NAME, albumid, releaseXmlNode)
@@ -108,4 +117,8 @@ class AlbumArtistStdName:
                       PLUGIN_NAME, albumid, releaseXmlNode)
         return None
 
-register_album_metadata_processor(AlbumArtistStdName().add_artist_std_name)
+# Register the plugin to run at a LOW priority so that other plugins that
+# modify the contents of the _albumartists and _albumartists_sort lists can
+# complete their processing and this plugin is working with the latest
+# updated data.
+register_album_metadata_processor(AlbumArtistStdName().add_artist_std_name, priority=PluginPriority.LOW)

--- a/plugins/albumartistextension/albumartistextension.py
+++ b/plugins/albumartistextension/albumartistextension.py
@@ -103,9 +103,9 @@ class AlbumArtistStdName:
                         log.error("%s: %r: Missing 'artist' in XML contents: %s",
                                 PLUGIN_NAME, albumid, releaseXmlNode)
                     aCount += 1
-                else:
-                    log.error("%s: %r: Missing 'name_credit' in XML contents: %s",
-                            PLUGIN_NAME, albumid, releaseXmlNode)
+            else:
+                log.error("%s: %r: Missing 'name_credit' in XML contents: %s",
+                        PLUGIN_NAME, albumid, releaseXmlNode)
             if len(stdArtist) > 0:
                 album_metadata["~aaeStdAlbumArtists"] = stdArtist
             if len(credArtist) > 0:

--- a/plugins/albumartistextension/albumartistextension.py
+++ b/plugins/albumartistextension/albumartistextension.py
@@ -43,7 +43,6 @@ class AlbumArtistStdName:
             stdArtist = ""
             sortArtist = ""
             aCount = 0
-            jPhrase = []
             # The 'name_credit' child should always be there.
             # This check is to avoid a runtime error if it doesn't exist for some reason.
             if 'name_credit' in releaseXmlNode.artist_credit[0].children:


### PR DESCRIPTION
# AlbumArtist Extension
This plugin provides ***standardized***, ***credited*** and ***sorted*** artist information for the album artist.  This is useful when your tagging or renaming scripts require both the standardized artist name and the credited artist name, or more detailed information about the album artists.

## Output
The information is provided in the following variables:

* **\_aaeStdAlbumArtists** = The standardized version of album artist(s)

* **\_aaeCredAlbumArtists** = The credited version of album artist(s)

* **\_aaeSortAlbumArtists** = The sorted version of album artist(s)

* **\_aaeAlbumArtistCount** = The number of artists comprising the album artist.

* **\_aaeStdAlbumArtist\_n** = The standardized version of the album artists, where **n** is the number of the artist in the list starting at **0**.  If there are two artists in the AlbumArtist tag, then they will be available in the **\_aaeStdAlbumArtist\_0** and **\_aaeStdAlbumArtist\_1** variables. 

* **\_aaeCredAlbumArtist\_n** = The credited version of the album artists, where **n** is the number of the artist in the list starting at **0**.  If there are two artists in the AlbumArtist tag, then they will be available in the **\_aaeCredAlbumArtist\_0** and **\_aaeCredAlbumArtist\_1** variables.

* **\_aaeSortAlbumArtists\_n** = The sorted version of the album artists, where **n** is the number of the artist in the list starting at **0**.  If there are two artists in the AlbumArtist tag, then they will be available in the **\_aaeSortAlbumArtist\_0** and **\_aaeSortAlbumArtist\_1** variables.

* **\_aaeJoinPhrase\_n** = The phrases used to join the album artists, where **n** is the number of the phrase in the list starting at **0**.  **NOTE:** This variable will not be provided if there is only one artist in the AlbumArtist tag.  The user should check that **\_aaeAlbumArtistCount** is greater than one before using this variable.

**PLEASE NOTE:** Tagger scripts are required to make use of these hidden variables. Please see the notes on "Usage" below.

## Usage
The following are examples of simple Picard file naming scripts to illustrate the use of the variables provided by this plugin.

### Example 1
File the album in a subdirectory of the standardized name of the first artist listed in the AlbumArtist tag.

    %_aaeStdAlbumArtist_0%/%album%/%title%

### Example 2
File the album in a subdirectory of the standardized names of all artists listed in the AlbumArtist tag.  This is similar to using the AlbumArtist tag with the 'Use standardized artist name' option checked in Picard.

    %_aaeStdAlbumArtists%/%album%/%title%

### Example 3
File the album in a subdirectory of the credited name of the first artist listed in the AlbumArtist tag.

    %_aaeCredAlbumArtist_0%/%album%/%title%

### Example 4
File the album in a subdirectory of the credited names of all artists listed in the AlbumArtist tag.  This is similar to using the AlbumArtist tag with the 'Use standardized artist name' option unchecked in Picard.

    %_aaeCredAlbumArtists%/%album%/%title%

### Example 5
File the album in a subdirectory of the sort name of the first artist listed in the AlbumArtist tag.

    %_aaeSortAlbumArtist_0%/%album%/%title%


### Example 6
File the album in a subdirectory of the sort names of all artists listed in the AlbumArtist tag.  This is similar to using the AlbumArtistSort tag.

    %_aaeStdAlbumArtists%/%album%/%title%

### Example 7
File the album in a custom subdirectory if there are multiple album artists.

    %_aaeCredAlbumArtist_0%$if($gt(%_aae_AlbumArtistCount,0), (et al.))/%album%/%title%

### Example 8
File the album in a subdirectory of the first character of the sort name of the first artist listed in the AlbumArtist tag, filing by the standardized name of the first album artist.

    $upper($firstalphachar(%_aaeSortAlbumArtist_0%,nonalpha="#"))/%_aaeStdAlbumArtist_0%/%album%/%title%

## Technical Notes
This plugin does not require any additional calls to the MusicBrainz servers.  It uses the information already provided with the original call, including items that are subsequently discarded by Picard.
