### PR TITLE
featartistsintitles.py: also remove feat. artists from sort tags

### DIFF
--- a/plugins/featartistsintitles/featartistsintitles.py
+++ b/plugins/featartistsintitles/featartistsintitles.py
@@ -1,7 +1,7 @@
 PLUGIN_NAME = 'Feat. Artists in Titles'
-PLUGIN_AUTHOR = 'Lukas Lalinsky, Michael Wiencek, Bryan Toth'
+PLUGIN_AUTHOR = 'Lukas Lalinsky, Michael Wiencek, Bryan Toth, JeromyNix (NobahdiAtoll)'
 PLUGIN_DESCRIPTION = 'Move "feat." from artist names to album and track titles. Match is case insensitive.'
-PLUGIN_VERSION = "0.3"
+PLUGIN_VERSION = "0.4"
 PLUGIN_API_VERSIONS = ["0.9.0", "0.10", "0.15", "0.16"]
 
 from picard.metadata import register_album_metadata_processor, register_track_metadata_processor
@@ -15,6 +15,9 @@ def move_album_featartists(tagger, metadata, release):
     if match:
         metadata["albumartist"] = match.group(1)
         metadata["album"] += " (feat.%s)" % match.group(2)
+    match = _feat_re.match(metadata["albumartistsort"])
+    if match:
+        metadata["albumartistsort"] = match.group(1)
 
 
 def move_track_featartists(tagger, metadata, release, track):
@@ -22,6 +25,9 @@ def move_track_featartists(tagger, metadata, release, track):
     if match:
         metadata["artist"] = match.group(1)
         metadata["title"] += " (feat.%s)" % match.group(2)
+    match = _feat_re.match(metadata["artistsort"])
+    if match:
+        metadata["artistsort"] = match.group(1)
 
 register_album_metadata_processor(move_album_featartists)
 register_track_metadata_processor(move_track_featartists)


### PR DESCRIPTION
Add matches for sort tags, so these are modified when the corresponding metadata tags are cleaned of featured artists.

Slight modification of JeromyNix (@NobahdiAtoll)'s changes, where credit is due (and given): https://github.com/NobahdiAtoll/MusicBrainzPicardPlugins/blob/master/featartistsintitlesfix.py

Resolves #62 