### PR TITLE
Change references to tagger.ws to tagger.webservice

### DIFF
--- a/plugins/acousticbrainz/acousticbrainz.py
+++ b/plugins/acousticbrainz/acousticbrainz.py
@@ -60,7 +60,7 @@ def result(album, metadata, data, reply, error):
 
 
 def process_track(album, metadata, release, track):
-    album.tagger.ws.download(
+    album.tagger.webservice.download(
         ACOUSTICBRAINZ_HOST,
         ACOUSTICBRAINZ_PORT,
         "/%s/high-level" % (metadata["musicbrainz_recordingid"]),

--- a/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
+++ b/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
@@ -48,7 +48,7 @@ class AcousticBrainz_Key:
             log.debug("%s: Add AcusticBrainz request for %s (%s)", PLUGIN_NAME, track_metadata['title'], recordingId)
             self.album_add_request(album)
             path = "/%s/low-level" % recordingId
-            return album.tagger.ws.get(
+            return album.tagger.webservice.get(
                         ACOUSTICBRAINZ_HOST,
                         ACOUSTICBRAINZ_PORT,
                         path,

--- a/plugins/albumartist_website/albumartist_website.py
+++ b/plugins/albumartist_website/albumartist_website.py
@@ -81,7 +81,7 @@ class AlbumArtistWebsite:
             port = config.setting["server_port"]
             path = "/ws/2/%s/%s" % ('artist', artistId)
             queryargs = {"inc": "url-rels"}
-            return album.tagger.ws.get(host, port, path,
+            return album.tagger.webservice.get(host, port, path,
                         partial(self.website_process, artistId),
                                 parse_response_type="xml", priority=True, important=False,
                                 queryargs=queryargs)

--- a/plugins/fanarttv/__init__.py
+++ b/plugins/fanarttv/__init__.py
@@ -81,7 +81,7 @@ class CoverArtProviderFanartTv(CoverArtProvider):
                      "client_key": QUrl.toPercentEncoding(self._client_key),
                      }
         log.debug("CoverArtProviderFanartTv.queue_downloads: %s" % path)
-        self.album.tagger.ws.download(
+        self.album.tagger.webservice.download(
             FANART_HOST,
             FANART_PORT,
             path,

--- a/plugins/tangoinfo/tangoinfo.py
+++ b/plugins/tangoinfo/tangoinfo.py
@@ -142,7 +142,7 @@ class TangoInfoTagger:
             path = '/%s' % (barcode)
 
             # Call website_process as a partial func
-            return album.tagger.ws.get(host, port, path,
+            return album.tagger.webservice.get(host, port, path,
                         partial(self.website_process, barcode, zeros),
                         parse_response_type=None, priority=False, important=False)
 


### PR DESCRIPTION
tagger.ws was never available in Picard.

This is untested, but it should work and is just #114 for other plugins :)