### PR TITLE
PICARD-1261: Use tag.startswith instead of accessing the first character by index

### DIFF
--- a/plugins/keep/keep.py
+++ b/plugins/keep/keep.py
@@ -26,6 +26,6 @@ def keep(parser, *keeptags):
     for tag in tags:
         if (transltag(tag) not in keeptags and
             not tag.startswith("musicbrainz_") and
-                not tag[0] == "~"):
+                not tag.startswith("~")):
             parser.context.pop(tag, None)
     return ""


### PR DESCRIPTION
In PICARD-1261, the following error happened:

```
[...]
File "C:\Users\Admin\AppData\Local\MusicBrainz\Picard\plugins\keep.zip\keep.py", line 29, in keep
not tag[0] == "~"):
IndexError: string index out of range
```

Apparently, tag names can be completely empty. Use tag.startswith which deals
with this case correctly.