### PR TITLE
standardise_performer: Fixed RuntimeError

### DIFF
--- a/plugins/standardise_performers/standardise_performers.py
+++ b/plugins/standardise_performers/standardise_performers.py
@@ -22,7 +22,7 @@ Performer [synthesizer]: Lol Creme
 Performer [tambourine]: Graham Gouldman
 </pre>
 '''
-PLUGIN_VERSION = '0.2'
+PLUGIN_VERSION = '0.3'
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0", "1.3.0", "2.0"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -35,7 +35,7 @@ standardise_performers_split = re.compile(r", | and ").split
 
 
 def standardise_performers(album, metadata, *args):
-    for key, values in metadata.rawitems():
+    for key, values in list(metadata.rawitems()):
         if not key.startswith('performer:') \
                 and not key.startswith('~performersort:'):
             continue


### PR DESCRIPTION
In Python 3 it is no longer valid to modify the size of a dictionary that is iterated via .rawitems(), since .rawitems() returns an iterator instead of a list.

See https://community.metabrainz.org/t/standardise-performers-plugin-doesnt-work-with-python3/391982