### PR TITLE
Show 'guest, 'solo' and 'additional' on all related performer tags

### DIFF
--- a/plugins/standardise_performers/standardise_performers.py
+++ b/plugins/standardise_performers/standardise_performers.py
@@ -35,10 +35,7 @@ standardise_performers_split = re.compile(r", | and ").split
 
 
 def standardise_performers(album, metadata, *args):
-    for key, values in list(metadata.rawitems()):
-        if not key.startswith('performer:') \
-                and not key.startswith('~performersort:'):
-            continue
+    for key, values in list(filter(lambda filter_tuple: filter_tuple[0].startswith('performer:') or filter_tuple[0].startswith('~performersort:'), metadata.rawitems())):
         mainkey, subkey = key.split(':', 1)
         if not subkey:
             continue

--- a/plugins/standardise_performers/standardise_performers.py
+++ b/plugins/standardise_performers/standardise_performers.py
@@ -22,7 +22,7 @@ Performer [synthesizer]: Lol Creme
 Performer [tambourine]: Graham Gouldman
 </pre>
 '''
-PLUGIN_VERSION = '0.3'
+PLUGIN_VERSION = '0.4'
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0", "1.3.0", "2.0"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -49,8 +49,16 @@ def standardise_performers(album, metadata, *args):
                   PLUGIN_NAME,
                   subkey,
                   )
+        extra = ''
+        temp = ''
+        for part in instruments[0].split():
+            if part in ['guest', 'solo', 'additional']:
+                extra = "{0}{1} ".format(extra, part)
+            else:
+                temp = "{0} {1}".format(temp, part).strip()
+        instruments[0] = temp
         for instrument in instruments:
-            newkey = '%s:%s' % (mainkey, instrument)
+            newkey = '%s:%s%s' % (mainkey, extra, instrument)
             for value in values:
                 metadata.add_unique(newkey, value)
         del metadata[key]

--- a/plugins/standardise_performers/standardise_performers.py
+++ b/plugins/standardise_performers/standardise_performers.py
@@ -35,7 +35,10 @@ standardise_performers_split = re.compile(r", | and ").split
 
 
 def standardise_performers(album, metadata, *args):
-    for key, values in list(filter(lambda filter_tuple: filter_tuple[0].startswith('performer:') or filter_tuple[0].startswith('~performersort:'), metadata.rawitems())):
+    for key, values in list(metadata.rawitems()):
+        if not key.startswith('performer:') \
+                and not key.startswith('~performersort:'):
+            continue
         mainkey, subkey = key.split(':', 1)
         if not subkey:
             continue

--- a/plugins/standardise_performers/standardise_performers.py
+++ b/plugins/standardise_performers/standardise_performers.py
@@ -49,16 +49,17 @@ def standardise_performers(album, metadata, *args):
                   PLUGIN_NAME,
                   subkey,
                   )
-        extra = ''
-        temp = ''
-        for part in instruments[0].split():
-            if part in ['guest', 'solo', 'additional']:
-                extra = "{0}{1} ".format(extra, part)
-            else:
-                temp = "{0} {1}".format(temp, part).strip()
-        instruments[0] = temp
+        prefixes = []
+        words = instruments[0].split()
+        for word in words[:]:
+            if not word in ['guest', 'solo', 'additional', 'minor']:
+                break
+            prefixes.append(word)
+            words.remove(word)
+        instruments[0] = " ".join(words)
+        prefix = " ".join(prefixes) + " " if prefixes else ""
         for instrument in instruments:
-            newkey = '%s:%s%s' % (mainkey, extra, instrument)
+            newkey = '%s:%s%s' % (mainkey, prefix, instrument)
             for value in values:
                 metadata.add_unique(newkey, value)
         del metadata[key]


### PR DESCRIPTION
In response to the discussion at [https://community.metabrainz.org/t/retrieving-entering-guest-and-additional-attributes-for-performers-playing-more-than-one-instrument/400201](https://community.metabrainz.org/t/retrieving-entering-guest-and-additional-attributes-for-performers-playing-more-than-one-instrument/400201), the plugin has been updated as suggested by @Sophist-UK.