### PR TITLE
Handle exceptions with in Tonal Rhythm Plugin

### DIFF
--- a/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
+++ b/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
@@ -27,7 +27,7 @@ from the AcousticBrainz database.<br/><br/>
 '''
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = '1.1'
+PLUGIN_VERSION = '1.1.1'
 PLUGIN_API_VERSIONS = ["2.0"]  # Requires support for TKEY which is in 1.4
 
 from picard import log
@@ -45,7 +45,7 @@ ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 50)
 class AcousticBrainz_Key:
 
     def get_data(self, album, track_metadata, trackXmlNode, releaseXmlNode):
-        if not musicbrainz_recordingid in track_metadata:            
+        if not musicbrainz_recordingid in track_metadata:
             log.error("%s: Error parsing response. No MusicBrainz recording id found.",
                       PLUGIN_NAME)
             return

--- a/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
+++ b/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
@@ -34,6 +34,7 @@ from picard import log
 from picard.metadata import register_track_metadata_processor
 from functools import partial
 from picard.webservice import ratecontrol
+from picard.util import parse_json
 
 ACOUSTICBRAINZ_HOST = "acousticbrainz.org"
 ACOUSTICBRAINZ_PORT = 80
@@ -44,9 +45,14 @@ ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 50)
 class AcousticBrainz_Key:
 
     def get_data(self, album, track_metadata, trackXmlNode, releaseXmlNode):
+        if not musicbrainz_recordingid in track_metadata:            
+            log.error("%s: Error parsing response. No MusicBrainz recording id found.",
+                      PLUGIN_NAME)
+            return
         recordingId = track_metadata['musicbrainz_recordingid']
         if recordingId:
-            log.debug("%s: Add AcusticBrainz request for %s (%s)", PLUGIN_NAME, track_metadata['title'], recordingId)
+            log.debug("%s: Add AcousticBrainz request for %s (%s)",
+                      PLUGIN_NAME, track_metadata['title'], recordingId)
             self.album_add_request(album)
             path = "/%s/low-level" % recordingId
             return album.tagger.webservice.get(
@@ -54,16 +60,23 @@ class AcousticBrainz_Key:
                         ACOUSTICBRAINZ_PORT,
                         path,
                         partial(self.process_data, album, track_metadata),
-                        priority=True, important=False)
-        return
+                        priority=True,
+                        important=False,
+                        parse_response_type=None)
 
     def process_data(self, album, track_metadata, response, reply, error):
         if error:
             log.error("%s: Network error retrieving acousticBrainz data for recordingId %s",
-                PLUGIN_NAME, track_metadata['musicbrainz_recordingid'])
+                      PLUGIN_NAME, track_metadata['musicbrainz_recordingid'])
             self.album_remove_request(album)
             return
-        data = response
+        try:
+            data = parse_json(response)
+        except JSONDecodeError:
+            log.error("%s: Network error retrieving AcousticBrainz data for recordingId %s",
+                      PLUGIN_NAME, track_metadata['musicbrainz_recordingid'])
+            self.album_remove_request(album)
+            return
         if "tonal" in data:
             if "key_key" in data["tonal"]:
                 key = data["tonal"]["key_key"]


### PR DESCRIPTION
When AcousticBrainz was down during a recent migration and was returning HTML instead of the expected JSON data it caused Picard to crash if the AB plugin was enabled. I have update the AcousticBrainz Tonal-Rhythm plugin for better error handling to avoid crashes.