### PR TITLE
addrelease: Handle disc number tags with totaldisc information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,4 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-before_install:
-  - pip3 install picard
 script: python test.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 dist: xenial
 language: python
+cache:
+  pip: true
 python:
   - "3.5"
   - "3.6"
   - "3.7"
+before_install:
+  - pip3 install picard
 script: python test.py

--- a/plugins/addrelease/addrelease.py
+++ b/plugins/addrelease/addrelease.py
@@ -171,11 +171,10 @@ class AddClusterAsRelease(AddObjectAsEntity):
                 # disc numbers need to be changed to accommodate that.
                 self.discnumber_shift = max(self.discnumber_shift, 0 - m)
             m = m + self.discnumber_shift
-        except Exception as e:
+        except ValueError as e:
             # The most likely reason for an exception at this point is a
-            # ValueError because the disc number in the tags was not a
-            # number. Just log the exception and assume the medium number
-            # is 0.
+            # because the disc number in the tags was not a number. Just log
+            # the exception and assume the medium number is 0.
             log.info("Trying to get the disc number of %s caused the following error: %s; assuming 0",
                      metadata["~filename"], e)
             m = 0

--- a/plugins/addrelease/addrelease.py
+++ b/plugins/addrelease/addrelease.py
@@ -172,9 +172,9 @@ class AddClusterAsRelease(AddObjectAsEntity):
                 self.discnumber_shift = max(self.discnumber_shift, 0 - m)
             m = m + self.discnumber_shift
         except ValueError as e:
-            # The most likely reason for an exception at this point is a
-            # because the disc number in the tags was not a number. Just log
-            # the exception and assume the medium number is 0.
+            # The most likely reason for an exception at this point is because
+            # the disc number in the tags was not a number. Just log the
+            # exception and assume the medium number is 0.
             log.info("Trying to get the disc number of %s caused the following error: %s; assuming 0",
                      metadata["~filename"], e)
             m = 0

--- a/plugins/addrelease/addrelease.py
+++ b/plugins/addrelease/addrelease.py
@@ -6,7 +6,7 @@ PLUGIN_DESCRIPTION = "Adds a plugin context menu option to clusters and single\
  files to help you quickly add them as releases or standalone recordings to\
  the MusicBrainz database via the website by pre-populating artists,\
  track names and times."
-PLUGIN_VERSION = "0.7.2"
+PLUGIN_VERSION = "0.7.3"
 PLUGIN_API_VERSIONS = ["2.0"]
 
 from picard import config, log
@@ -128,6 +128,8 @@ class AddClusterAsRelease(AddObjectAsEntity):
         # to produce a sane disc number.
         try:
             discnumber = metadata.get("discnumber", "1")
+            # Split off any totaldiscs information
+            discnumber = discnumber.split("/", 1)[0]
             m = int(discnumber)
             if m <= 0:
                 # A disc number was smaller than or equal to 0 - all other

--- a/plugins/addrelease/addrelease.py
+++ b/plugins/addrelease/addrelease.py
@@ -121,6 +121,41 @@ class AddClusterAsRelease(AddObjectAsEntity):
         self.discnumber_shift = -1
 
     def extract_discnumber(self, metadata):
+        """
+        >>> from picard.metadata import Metadata
+        >>> m = Metadata()
+        >>> AddClusterAsRelease().extract_discnumber(m)
+        0
+        >>> m["discnumber"] = "boop"
+        >>> AddClusterAsRelease().extract_discnumber(m)
+        0
+        >>> m["discnumber"] = "1"
+        >>> AddClusterAsRelease().extract_discnumber(m)
+        0
+        >>> m["discnumber"] = 1
+        >>> AddClusterAsRelease().extract_discnumber(m)
+        0
+        >>> m["discnumber"] = -1
+        >>> AddClusterAsRelease().extract_discnumber(m)
+        0
+        >>> m["discnumber"] = "1/1"
+        >>> AddClusterAsRelease().extract_discnumber(m)
+        0
+        >>> m["discnumber"] = "2/2"
+        >>> AddClusterAsRelease().extract_discnumber(m)
+        1
+        >>> a = AddClusterAsRelease()
+        >>> m["discnumber"] = "-2/2"
+        >>> a.extract_discnumber(m)
+        0
+        >>> m["discnumber"] = "-1/4"
+        >>> a.extract_discnumber(m)
+        1
+        >>> m["discnumber"] = "1/4"
+        >>> a.extract_discnumber(m)
+        3
+
+        """
         # As per https://musicbrainz.org/doc/Development/Release_Editor_Seeding#Tracklists_data
         # the medium numbers ("m") must be starting with 0.
         # Maybe the existing tags don't have disc numbers in them or
@@ -209,3 +244,7 @@ class AddFileAsRelease(AddObjectAsEntity):
 register_cluster_action(AddClusterAsRelease())
 register_file_action(AddFileAsRecording())
 register_file_action(AddFileAsRelease())
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/test.py
+++ b/test.py
@@ -6,12 +6,6 @@ import tempfile
 import unittest
 from generate import build_json, zip_files
 
-# python 2 & 3 compatibility
-try:
-    basestring
-except NameError:
-    basestring = str
-
 
 class GenerateTestCase(unittest.TestCase):
 
@@ -86,11 +80,13 @@ class GenerateTestCase(unittest.TestCase):
 
         # All plugins should contain all required fields
         for module_name, data in plugin_json.items():
-            self.assertIsInstance(data['name'], basestring)
+            self.assertIsInstance(data['name'], str)
             self.assertIsInstance(data['api_versions'], list)
-            self.assertIsInstance(data['author'], basestring)
-            self.assertIsInstance(data['description'], basestring)
-            self.assertIsInstance(data['version'], basestring)
+            self.assertIsInstance(data['author'], str)
+            self.assertIsInstance(data['description'], str)
+            self.assertIsInstance(data['version'], str)
+
+
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -1,4 +1,3 @@
-import doctest
 import os
 import glob
 import json
@@ -86,12 +85,6 @@ class GenerateTestCase(unittest.TestCase):
             self.assertIsInstance(data['author'], str)
             self.assertIsInstance(data['description'], str)
             self.assertIsInstance(data['version'], str)
-
-
-def load_tests(loader, tests, ignore):
-    from plugins.addrelease import addrelease
-    tests.addTests(doctest.DocTestSuite(addrelease))
-    return tests
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+import doctest
 import os
 import glob
 import json
@@ -87,6 +88,10 @@ class GenerateTestCase(unittest.TestCase):
             self.assertIsInstance(data['version'], str)
 
 
+def load_tests(loader, tests, ignore):
+    from plugins.addrelease import addrelease
+    tests.addTests(doctest.DocTestSuite(addrelease))
+    return tests
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This also removes some Python 2 compatibility code in `test.py` and adds doctests for the disc number extraction.

I don't feel strongly about using doctests, but it seemed the easiest solution without always importing unittest, even if just importing the plugin in Picard.