### PR TITLE
Don't test on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
 script: python test.py


### PR DESCRIPTION
Picard doesn't support Python 3.4, so making sure plugins work on it is not
useful.

Python 3.4 is also not a requirement for the infrastructure that builds the
website.