### PR TITLE
Update plugins/wikidata/wikidata.py

### DIFF
--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -33,23 +33,27 @@ class wikidata:
         # key: mbid, value: list of strings containing the genre's
         self.cache = {}
 
-        # find the mb url if this exists
-        self.mb_host = config.setting["server_host"]
-        self.mb_port = config.setting["server_port"]
+        # metabrainz url
+        self.mb_host = ''
+        self.mb_port = ''
+
+        # web service & logger
+        self.ws = None
+        self.log = None
 
     # not used
     def process_release(self, album, metadata, release):
         self.ws = album.tagger.webservice
         self.log = album.log
         item_id = dict.get(metadata, 'musicbrainz_releasegroupid')[0]
-        
+
         log.info('WIKIDATA: processing release group %s ' % item_id)
         self.process_request(metadata, album, item_id, type='release-group')
         for artist in dict.get(metadata, 'musicbrainz_albumartistid'):
             item_id = artist
             log.info('WIKIDATA: processing release artist %s' % item_id)
             self.process_request(metadata, album, item_id, type='artist')
-            
+
     # Main processing function
     # First see if we have already found what we need in the cache, finalize loading
     # Next see if we are already looking for the item
@@ -183,7 +187,7 @@ class wikidata:
                 for metadata in self.requests[item_id]:
                     new_genre = set(metadata.getall("genre"))
                     new_genre.update(genre_list)
-                    #sort the new genre list so that they don't appear as new entries (not a change) next time
+                    # sort the new genre list so that they don't appear as new entries (not a change) next time
                     metadata["genre"] = sorted(new_genre)
                     self.cache[item_id] = genre_list
                     log.debug('WIKIDATA: setting genre : %s ' % genre_list)
@@ -191,7 +195,7 @@ class wikidata:
             else:
                 log.info('WIKIDATA: Genre not found in wikidata')
 
-            log.info('WIKIDATA: Seeing if we can finalize tags %s  ' % len(self.albums[item_id]))
+            log.info('WIKIDATA: Seeing if we can finalize tags %d  ' % len(self.albums[item_id]))
 
             for album in self.albums[item_id]:
                 album._requests -= 1
@@ -201,6 +205,8 @@ class wikidata:
                 log.info('WIKIDATA:  TOTAL REMAINING REQUESTS %s' % album._requests)
 
     def process_track(self, album, metadata, trackXmlNode, releaseXmlNode):
+        self.mb_host = config.setting["server_host"]
+        self.mb_port = config.setting["server_port"]
         self.ws = album.tagger.webservice
         self.log = album.log
 

--- a/plugins/wikidata/wikidata.py
+++ b/plugins/wikidata/wikidata.py
@@ -8,14 +8,12 @@
 PLUGIN_NAME = 'wikidata-genre'
 PLUGIN_AUTHOR = 'Daniel Sobey, Sambhav Kothari'
 PLUGIN_DESCRIPTION = 'query wikidata to get genre tags'
-PLUGIN_VERSION = '1.1'
+PLUGIN_VERSION = '1.2'
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = 'WTFPL'
 PLUGIN_LICENSE_URL = 'http://www.wtfpl.net/'
 
 from functools import partial
-import threading
-
 from picard import config, log
 from picard.metadata import register_track_metadata_processor
 
@@ -23,12 +21,11 @@ from picard.metadata import register_track_metadata_processor
 class Wikidata:
 
     def __init__(self):
-        self.lock = threading.Lock()
         # Key: mbid, value: List of metadata entries to be updated when we have parsed everything
         self.requests = {}
 
         # Key: mbid, value: List of items to track the number of outstanding requests
-        self.albums = {}
+        self.itemAlbums = {}
 
         # cache, items that have been found
         # key: mbid, value: list of strings containing the genre's
@@ -48,60 +45,59 @@ class Wikidata:
         self.log = album.log
         item_id = dict.get(metadata, 'musicbrainz_releasegroupid')[0]
 
-        log.info('WIKIDATA: processing release group %s ' % item_id)
+        log.info('WIKIDATA: Processing release group %s ' % item_id)
         self.process_request(metadata, album, item_id, type='release-group')
         for artist in dict.get(metadata, 'musicbrainz_albumartistid'):
             item_id = artist
-            log.info('WIKIDATA: processing release artist %s' % item_id)
+            log.info('WIKIDATA: Processing release artist %s' % item_id)
             self.process_request(metadata, album, item_id, type='artist')
 
     # Main processing function
     # First see if we have already found what we need in the cache, finalize loading
     # Next see if we are already looking for the item
-    #   If we are add this item to the list of items to be updated once we find what we are looking for.
+    #   If we are, add this item to the list of items to be updated once we find what we are looking for.
     #   Otherwise we are the first one to look up this item, start a new request
     # metadata, map containing the new metadata
     #
     def process_request(self, metadata, album, item_id, type):
-        with self.lock:
-            log.debug('WIKIDATA: Looking up cache for item  %s' % item_id)
-            log.debug('WIKIDATA: requests %s' % album._requests)
-            log.debug('WIKIDATA: TYPE %s' % type)
-            if item_id in self.cache:
-                log.info('WIKIDATA: found in cache')
-                genre_list = self.cache[item_id]
-                new_genre = set(metadata.getall("genre"))
-                new_genre.update(genre_list)
-                #sort the new genre list so that they don't appear as new entries (not a change) next time
-                metadata["genre"] = sorted(new_genre)
-                return
+        log.debug('WIKIDATA: Looking up cache for item: %s' % item_id)
+        log.debug('WIKIDATA: Album request count: %s' % album._requests)
+        log.debug('WIKIDATA: Item type %s' % type)
+        if item_id in self.cache:
+            log.debug('WIKIDATA: Found item in cache')
+            genre_list = self.cache[item_id]
+            new_genre = set(metadata.getall("genre"))
+            new_genre.update(genre_list)
+            #sort the new genre list so that they don't appear as new entries (not a change) next time
+            metadata["genre"] = sorted(new_genre)
+            return
+        else:
+            # pending requests are handled by adding the metadata object to a
+            # list of things to be updated when the genre is found
+            if item_id in self.itemAlbums:
+                log.debug(
+                    'WIKIDATA: Request already pending, add it to the list of items to update once this has been'
+                    'found')
+                self.requests[item_id].append(metadata)
             else:
-                # pending requests are handled by adding the metadata object to a
-                # list of things to be updated when the genre is found
-                if item_id in self.albums:
-                    log.debug(
-                        'WIKIDATA: request already pending, add it to the list of items to update once this has been found')
-                    self.requests[item_id].append(metadata)
+                self.requests[item_id] = [metadata]
+                self.itemAlbums[item_id] = album
+                album._requests += 1
 
-                else:
-                    self.requests[item_id] = [metadata]
-                    album._requests += 1
-                    self.albums[item_id] = [album]
+                log.debug('WIKIDATA: First request for this item')
+                log.debug('WIKIDATA: About to call Musicbrainz to look up %s ' % item_id)
 
-                    log.debug('WIKIDATA: first request for this item')
-                    log.info('WIKIDATA: about to call musicbrainz to look up %s ' % item_id)
+                path = '/ws/2/%s/%s' % (type, item_id)
+                queryargs = {"inc": "url-rels"}
 
-                    path = '/ws/2/%s/%s' % (type, item_id)
-                    queryargs = {"inc": "url-rels"}
-
-                    self.ws.get(self.mb_host, self.mb_port, path, partial(self.musicbrainz_release_lookup, item_id,
-                                                                          metadata),
-                                parse_response_type="xml", priority=False, important=False, queryargs=queryargs)
+                self.ws.get(self.mb_host, self.mb_port, path, partial(self.musicbrainz_release_lookup, item_id,
+                                                                      metadata),
+                            parse_response_type="xml", priority=False, important=False, queryargs=queryargs)
 
     def musicbrainz_release_lookup(self, item_id, metadata, response, reply, error):
         found = False
         if error:
-            log.info('WIKIDATA: error retrieving release group info')
+            log.error('WIKIDATA: Error retrieving release group info')
         else:
             if 'metadata' in response.children:
                 if 'release_group' in response.metadata[0].children:
@@ -126,22 +122,24 @@ class Wikidata:
                                 wikidata_url = relation.target[0].text
                                 self.process_wikidata(wikidata_url, item_id)
         if not found:
-            log.info('WIKIDATA: no wikidata url found for item_id: %s ', item_id)
-        with self.lock:
-            for album in self.albums[item_id]:
-                album._requests -= 1
-                log.debug('WIKIDATA:  TOTAL REMAINING REQUESTS %s' % album._requests)
-                if not album._requests:
-                    self.albums[item_id].remove(album)
-                    album._finalize_loading(None)
+            log.debug('WIKIDATA: No wikidata url found for item_id: %s ', item_id)
+
+        album = self.itemAlbums[item_id]
+        album._requests -= 1
+        if not album._requests:
+            self.itemAlbums = {k: v for k, v in self.itemAlbums.items() if v != album}
+            album._finalize_loading(None)
+        log.info('WIKIDATA: Total remaining requests: %s' % album._requests)
+        if not self.itemAlbums:
+            self.requests.clear()
+            log.info('WIKIDATA: Finished.')
 
     def process_wikidata(self, wikidata_url, item_id):
-        with self.lock:
-            for album in self.albums[item_id]:
-                album._requests += 1
+        album = self.itemAlbums[item_id]
+        album._requests += 1
         item = wikidata_url.split('/')[4]
         path = "/wiki/Special:EntityData/" + item + ".rdf"
-        log.info('WIKIDATA: fetching the folowing url wikidata.org%s' % path)
+        log.debug('WIKIDATA: Fetching from wikidata.org%s' % path)
         self.ws.get('www.wikidata.org', 443, path,
                     partial(self.parse_wikidata_response, item, item_id),
                     parse_response_type="xml", priority=False, important=False)
@@ -164,7 +162,7 @@ class Wikidata:
                                             tmp = i.attribs.get('resource')
                                             if 'entity' == tmp.split('/')[3] and len(tmp.split('/')) == 5:
                                                 genre_id = tmp.split('/')[4]
-                                                log.info(
+                                                log.debug(
                                                     'WIKIDATA: Found the wikidata id for the genre: %s' % genre_id)
                                                 genre_entries.append(tmp)
                         else:
@@ -175,35 +173,34 @@ class Wikidata:
                                         if node2.attribs.get('lang') == 'en':
                                             genre = node2.text.title()
                                             genre_list.append(genre)
-                                            log.debug(
-                                                'Our genre is: %s' % genre)
+                                            log.debug('Our genre is: %s' % genre)
 
-        with self.lock:
-            if len(genre_list) > 0:
-                log.info('WIKIDATA: final list of wikidata id found: %s' % genre_entries)
-                log.info('WIKIDATA: final list of genre: %s' % genre_list)
+        if len(genre_list) > 0:
+            log.debug('WIKIDATA: item_id: %s' % item_id)
+            log.debug('WIKIDATA: Final list of wikidata id found: %s' % genre_entries)
+            log.debug('WIKIDATA: Final list of genre: %s' % genre_list)
+            log.info('WIKIDATA: Total items to update: %d ' % len(self.requests[item_id]))
+            for metadata in self.requests[item_id]:
+                new_genre = set(metadata.getall("genre"))
+                new_genre.update(genre_list)
+                # sort the new genre list so that they don't appear as new entries (not a change) next time
+                metadata["genre"] = sorted(new_genre)
+                self.cache[item_id] = genre_list
+                log.debug('WIKIDATA: Setting genre: %s ' % genre_list)
+        else:
+            log.debug('WIKIDATA: Genre not found in wikidata')
 
-                log.debug('WIKIDATA: total items to update: %s ' %
-                          len(self.requests[item_id]))
-                for metadata in self.requests[item_id]:
-                    new_genre = set(metadata.getall("genre"))
-                    new_genre.update(genre_list)
-                    # sort the new genre list so that they don't appear as new entries (not a change) next time
-                    metadata["genre"] = sorted(new_genre)
-                    self.cache[item_id] = genre_list
-                    log.debug('WIKIDATA: setting genre : %s ' % genre_list)
+        log.debug('WIKIDATA: Seeing if we can finalize tags...')
 
-            else:
-                log.info('WIKIDATA: Genre not found in wikidata')
-
-            log.info('WIKIDATA: Seeing if we can finalize tags %d  ' % len(self.albums[item_id]))
-
-            for album in self.albums[item_id]:
-                album._requests -= 1
-                if not album._requests:
-                    self.albums[item_id].remove(album)
-                    album._finalize_loading(None)
-                log.info('WIKIDATA:  TOTAL REMAINING REQUESTS %s' % album._requests)
+        album = self.itemAlbums[item_id]
+        album._requests -= 1
+        if not album._requests:
+            self.itemAlbums = {k: v for k, v in self.itemAlbums.items() if v != album}
+            album._finalize_loading(None)
+        log.info('WIKIDATA: Total remaining requests: %s' % album._requests)
+        if not self.itemAlbums:
+            self.requests.clear()
+            log.info('WIKIDATA: Finished.')
 
     def process_track(self, album, metadata, trackXmlNode, releaseXmlNode):
         self.mb_host = config.setting["server_host"]
@@ -211,24 +208,24 @@ class Wikidata:
         self.ws = album.tagger.webservice
         self.log = album.log
 
+        log.info('WIKIDATA: Processing Track...')
         for release_group in metadata.getall('musicbrainz_releasegroupid'):
-            log.debug('WIKIDATA: looking up release group metadata for %s ' % release_group)
+            log.debug('WIKIDATA: Looking up release group metadata for %s ' % release_group)
             self.process_request(metadata, album, release_group, type='release-group')
 
         for artist in metadata.getall('musicbrainz_albumartistid'):
-            log.info('WIKIDATA: processing release artist %s' % artist)
+            log.debug('WIKIDATA: Processing release artist %s' % artist)
             self.process_request(metadata, album, artist, type='artist')
 
         for artist in metadata.getall('musicbrainz_artistid'):
-            log.info('WIKIDATA: processing track artist %s' % artist)
+            log.debug('WIKIDATA: Processing track artist %s' % artist)
             self.process_request(metadata, album, artist, type='artist')
 
         if 'musicbrainz_workid' in metadata:
             for workid in metadata.getall('musicbrainz_workid'):
-                log.info('WIKIDATA: processing track artist %s' % workid)
+                log.debug('WIKIDATA: Processing track artist %s' % workid)
                 self.process_request(metadata, album, workid, type='work')
 
 
 wikidata = Wikidata()
-# register_album_metadata_processor(wikidata.process_release)
 register_track_metadata_processor(wikidata.process_track)


### PR DESCRIPTION
Refer to 

https://tickets.metabrainz.org/browse/PICARD-1411 
https://community.metabrainz.org/t/picard-keeps-locking-up/358547/4

I was not liking some of the esoteric genres that came from last.fm, so I decided to try wikidata & while it worked for some cases, I found it was not always stable.  It seems like this is pretty well documented in the JIRA DB + community forums.

The most glaring issue was this recursion that happened when you right-click the "other versions" option to switch releases.  It would eventually call to finalize the album which would call run_track_metadata_processors which would call to process the track then to finalize again, and then...

So, I spent some time carefully stepping through & trying to understand the plugin flow & data structures that are in place.  I was able to deduce the one problematic call to finalize there was not needed & thus eliminate the recursion.  There are some locks they put in which seems to acknowledge a re-entrant issue, but perhaps they didn't see through to the recursion.  But as best I can tell, no other threads ever come in so I am not sure the locks are needed once the recursion problem is lifted.  I did some basic testing with both the recursion & the locks out & everything seemed to work ok for me.  But I left the locks in for now, in case there are some edge cases I am not seeing thus far.  Locks do represent a certain amount of overhead tho, so some consideration might be given to their removal.

Besides the recursion, I identified extra album insertions that may have been causing some albums to end up un-finalized.  Removing the extra insertions seems to have eliminated these dangling albums.

Also, I moved the server & port to instance variables to avoid hundred of unneeded config lookups.

The above items in combination seemed to also speed the overall process up a bit.  Nothing super-major, but noticeable. 

Lastly, I sorted the genre list because if left unsorted, the sets can come out in different order for every lookup, causing "false positives" for the genre field (looks like a change when, in fact,  just the order is changing).

I ran the unittests under the test folder & it said 68 tests OK.  Not sure if you had other tests or what, since this is my first PR on this project.  

