### PR TITLE
Work & Movement

### DIFF
--- a/plugins/workandmovement/__init__.py
+++ b/plugins/workandmovement/__init__.py
@@ -38,8 +38,8 @@ from picard.metadata import register_track_metadata_processor
 
 
 class Work:
-    def __init__(self, title, id=None):
-        self.id = id
+    def __init__(self, title, mbid=None):
+        self.mbid = mbid
         self.title = title
         self.is_movement = False
         self.is_work = False
@@ -51,12 +51,12 @@ class Work:
         if self.parent:
             s.append(str(self.parent))
         if self.is_movement:
-            type = 'Movement'
+            work_type = 'Movement'
         elif self.is_work:
-            type = 'Work'
+            work_type = 'Work'
         else:
-            type = 'Unknown'
-        s.append('%s %i: %s' % (type, self.part_number, self.title))
+            work_type = 'Unknown'
+        s.append('%s %i: %s' % (work_type, self.part_number, self.title))
         return '\n'.join(s)
 
 
@@ -194,7 +194,7 @@ def unset_work(metadata):
 
 def set_work(metadata, work):
     metadata['work'] = work.title
-    metadata['musicbrainz_workid'] = work.id
+    metadata['musicbrainz_workid'] = work.mbid
     metadata['showmovement'] = 1
 
 

--- a/plugins/workandmovement/__init__.py
+++ b/plugins/workandmovement/__init__.py
@@ -184,12 +184,12 @@ def parse_work(work_rel):
 
 
 def unset_work(metadata):
-    metadata.set('work', '')
-    metadata.set('musicbrainz_workid', '')
-    metadata.set('movement', '')
-    metadata.set('movementnumber', '')
-    metadata.set('movementtotal', '')
-    metadata.set('showmovement', '')
+    metadata.delete('work')
+    metadata.delete('musicbrainz_workid')
+    metadata.delete('movement')
+    metadata.delete('movementnumber')
+    metadata.delete('movementtotal')
+    metadata.delete('showmovement')
 
 
 def set_work(metadata, work):

--- a/plugins/workandmovement/roman.py
+++ b/plugins/workandmovement/roman.py
@@ -1,0 +1,80 @@
+"""Convert to and from Roman numerals"""
+
+__author__ = "Mark Pilgrim (f8dy@diveintopython.org)"
+__version__ = "1.4"
+__date__ = "8 August 2001"
+__copyright__ = """Copyright (c) 2001 Mark Pilgrim
+
+This program is part of "Dive Into Python", a free Python tutorial for
+experienced programmers.  Visit http://diveintopython.org/ for the
+latest version.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the Python 2.1.1 license, available at
+http://www.python.org/2.1.1/license.html
+"""
+
+import re
+
+#Define exceptions
+class RomanError(Exception): pass
+class OutOfRangeError(RomanError): pass
+class NotIntegerError(RomanError): pass
+class InvalidRomanNumeralError(RomanError): pass
+
+#Define digit mapping
+romanNumeralMap = (('M',  1000),
+                   ('CM', 900),
+                   ('D',  500),
+                   ('CD', 400),
+                   ('C',  100),
+                   ('XC', 90),
+                   ('L',  50),
+                   ('XL', 40),
+                   ('X',  10),
+                   ('IX', 9),
+                   ('V',  5),
+                   ('IV', 4),
+                   ('I',  1))
+
+def toRoman(n):
+    """convert integer to Roman numeral"""
+    if not isinstance(n, int):
+        raise NotIntegerError("decimals can not be converted")
+    if not (0 < n < 5000):
+        raise OutOfRangeError("number out of range (must be 1..4999)")
+
+    result = ""
+    for numeral, integer in romanNumeralMap:
+        while n >= integer:
+            result += numeral
+            n -= integer
+    return result
+
+#Define pattern to detect valid Roman numerals
+romanNumeralPattern = re.compile("""
+    ^                   # beginning of string
+    M{0,4}              # thousands - 0 to 4 M's
+    (CM|CD|D?C{0,3})    # hundreds - 900 (CM), 400 (CD), 0-300 (0 to 3 C's),
+                        #            or 500-800 (D, followed by 0 to 3 C's)
+    (XC|XL|L?X{0,3})    # tens - 90 (XC), 40 (XL), 0-30 (0 to 3 X's),
+                        #        or 50-80 (L, followed by 0 to 3 X's)
+    (IX|IV|V?I{0,3})    # ones - 9 (IX), 4 (IV), 0-3 (0 to 3 I's),
+                        #        or 5-8 (V, followed by 0 to 3 I's)
+    $                   # end of string
+    """ ,re.VERBOSE)
+
+def fromRoman(s):
+    """convert Roman numeral to integer"""
+    if not s:
+        raise InvalidRomanNumeralError('Input can not be blank')
+    if not romanNumeralPattern.search(s):
+        raise InvalidRomanNumeralError('Invalid Roman numeral: %s' % s)
+
+    result = 0
+    index = 0
+    for numeral, integer in romanNumeralMap:
+        while s[index:index+len(numeral)] == numeral:
+            result += integer
+            index += len(numeral)
+    return result

--- a/plugins/workandmovement/workandmovement.py
+++ b/plugins/workandmovement/workandmovement.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+PLUGIN_NAME = 'Work & Movement'
+PLUGIN_AUTHOR = 'Philipp Wolfer'
+PLUGIN_DESCRIPTION = 'Set work and movement based on work relationships'
+PLUGIN_VERSION = '1.0'
+PLUGIN_API_VERSIONS = ['2.1']
+PLUGIN_LICENSE = 'GPL-2.0-or-later'
+PLUGIN_LICENSE_URL = 'https://www.gnu.org/licenses/gpl-2.0.html'
+
+
+import re
+
+from picard import log
+from picard.metadata import register_track_metadata_processor
+
+
+class Work:
+    def __init__(self, title, id):
+        self.id = id
+        self.title = title
+        self.is_movement = False
+        self.is_work = False
+        self.part_number = 0
+        self.parent = None
+
+    def __str__(self):
+        s = []
+        if self.parent:
+            s.append(str(self.parent))
+        if self.is_movement:
+            type = 'Movement'
+        elif self.is_work:
+            type = 'Work'
+        else:
+            type = 'Unknown'
+        s.append('%s %i: %s' % (type, self.part_number, self.title))
+        return '\n'.join(s)
+
+
+def is_performance_work(rel):
+    return (rel['target-type'] == 'work'
+            and rel['direction'] == 'forward'
+            and rel['type'] == 'performance')
+
+
+def is_parent_work(rel):
+    return (rel['target-type'] == 'work'
+            and rel['direction'] == 'backward'
+            and rel['type'] == 'parts')
+
+
+def is_movement_like(rel):
+    return ('movement' in rel['attributes']
+             or 'act' in rel['attributes']
+             or 'ordering-key' in rel)
+
+
+def is_child_work(rel):
+    return (rel['target-type'] == 'work'
+            and rel['direction'] == 'forward'
+            and rel['type'] == 'parts')
+
+
+part_number_re = re.compile(r'^[0-9IVXLC]+\.\s+')
+def remove_part_number(title):
+    return part_number_re.sub("", title)
+
+
+def normalize_movement_name(work, movement):
+    if movement.startswith(work):
+        movement = movement[len(work):].lstrip(':').strip()
+    # TODO: Extract the actual number, compate it to ordering-key
+    return remove_part_number(movement)
+
+
+def parse_work(work_rel):
+    work = Work(work_rel['title'], work_rel['id'])
+    if 'relations' in work_rel:
+        for rel in work_rel['relations']:
+            # If this work has parents and is linked to those as 'movement' or
+            # 'act' we consider it a part of a larger work and store it
+            # in the movement tag. The parent will be set as the work.
+            if is_parent_work(rel):
+                if is_movement_like(rel):
+                    work.is_movement = True
+                    work.part_number = rel['ordering-key']
+                    if 'work' in rel:
+                        work.parent = parse_work(rel['work'])
+                        work.parent.is_work = True
+                else:
+                    # Not a movement, but still part of a larger work.
+                    # Mark it as a work.
+                    work.is_work = True
+            # If this work has any parts, we consider it a proper work.
+            # This is a recording directly linked to a larger work.
+            if is_child_work(rel):
+                work.is_work = True
+    return work
+
+
+def unset_work(metadata):
+    metadata.set('work', '')
+    metadata.set('musicbrainz_workid', '')
+    metadata.set('movement', '')
+    metadata.set('movementnumber', '')
+    metadata.set('movementtotal', '')
+    metadata.set('showmovement', '')
+
+
+def set_work(metadata, work):
+    metadata['work'] = work.title
+    metadata['musicbrainz_workid'] = work.id
+    metadata['showmovement'] = 1
+
+
+def process_track(album, metadata, track, release):
+    if 'recording' in track:
+        recording = track['recording']
+    else:
+        recording = track
+
+    if not 'relations' in recording:
+        return
+
+    for rel in recording['relations']:
+        if is_performance_work(rel):
+            work = parse_work(rel['work'])
+            # Only use the first work that qualifies as a work or movement
+            log.debug('Found work:\n%s', work)
+            if work.is_movement or work.is_work:
+                break
+
+    unset_work(metadata)
+    if work:
+        if work.is_movement and work.parent and work.parent.is_work:
+            movement = normalize_movement_name(work.parent.title, work.title)
+            metadata['movement'] = movement
+            metadata['movementnumber'] = work.part_number
+            set_work(metadata, work.parent)
+        elif work.is_work:
+            set_work(metadata, work)
+
+
+register_track_metadata_processor(process_track)


### PR DESCRIPTION
This plugin uses MusicBrainz work information and the "&lt;Work&gt;: &lt;Number&gt;. &lt;Movement&gt;" naming convention to fill the `work`, `movement`, `movementnumber` and `showmovement` tags.

Work information is only used when it is part of a multi-level work, otherwise the work tag gets unset. See [PICARD-1050](https://tickets.metabrainz.org/browse/PICARD-1050) for a related discussion.

The goals of this plugin are:

- Provide an easy to use alternative to Classical Extras for users who want a simple way to add work and movement information to their files in a way that is compatible with iTunes and MusicBee.
- Serve as a testing ground to evaluate how to use MusicBrainz data to provide this information for eventual inclusion into Picard itself in the future

This plugin is meant to be used with Picard 2.1 which improves the support for the `work` tag and ads the movement related tags (https://github.com/metabrainz/picard/pull/1029).