### PR TITLE
Update GPL2/3 or later licenses

### DIFF
--- a/plugins/abbreviate_artistsort/abbreviate_artistsort.py
+++ b/plugins/abbreviate_artistsort/abbreviate_artistsort.py
@@ -20,9 +20,9 @@ e.g. "Vivaldi, Antonio" becomes "Vivaldi, A."
 This is particularly useful for classical albums that can have a long list of artists.
 %artistsort% is abbreviated into %_artistsort_abbrev% and
 %albumartistsort% is abbreviated into %_albumartistsort_abbrev%.'''
-PLUGIN_VERSION = "0.3"
+PLUGIN_VERSION = "0.4"
 PLUGIN_API_VERSIONS = ["1.0", "2.0"]
-PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 

--- a/plugins/albumartistextension/albumartistextension.py
+++ b/plugins/albumartistextension/albumartistextension.py
@@ -25,7 +25,7 @@ variables.
 
 PLUGIN_VERSION = "0.6"
 PLUGIN_API_VERSIONS = ["2.0"]
-PLUGIN_LICENSE = "GPL-2.0 or later"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 from picard import config, log

--- a/plugins/compatible_TXXX/compatible_TXXX.py
+++ b/plugins/compatible_TXXX/compatible_TXXX.py
@@ -7,7 +7,7 @@ by using only a single value for TXXX frames. Multiple value TXXX frames \
 technically don't comply with the ID3 specification."""
 PLUGIN_VERSION = "0.1"
 PLUGIN_API_VERSIONS = ["2.0"]
-PLUGIN_LICENSE = "GPL-2.0 or later"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 from picard import config

--- a/plugins/fanarttv/__init__.py
+++ b/plugins/fanarttv/__init__.py
@@ -20,9 +20,9 @@
 PLUGIN_NAME = 'fanart.tv cover art'
 PLUGIN_AUTHOR = 'Philipp Wolfer, Sambhav Kothari'
 PLUGIN_DESCRIPTION = 'Use cover art from fanart.tv. To use this plugin you have to register a personal API key on https://fanart.tv/get-an-api-key/'
-PLUGIN_VERSION = "1.4"
+PLUGIN_VERSION = "1.5"
 PLUGIN_API_VERSIONS = ["2.0"]
-PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 from functools import partial

--- a/plugins/fix_tracknums/fix_tracknums.py
+++ b/plugins/fix_tracknums/fix_tracknums.py
@@ -54,9 +54,9 @@ How to use:
   </li>
 </ol>
 '''
-PLUGIN_VERSION = '0.1'
+PLUGIN_VERSION = '0.2'
 PLUGIN_API_VERSIONS = ['0.15', '1.0', '2.0']
-PLUGIN_LICENSE = 'GPL-3.0'
+PLUGIN_LICENSE = 'GPL-3.0-or-later'
 PLUGIN_LICENSE_URL = 'https://www.gnu.org/licenses/gpl.txt'
 
 from picard import log

--- a/plugins/keep/keep.py
+++ b/plugins/keep/keep.py
@@ -8,7 +8,7 @@ beginning with `_`."""
 PLUGIN_VERSION = "1.1"
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0",
                        "1.3.0", "2.0"]
-PLUGIN_LICENSE = "GPL-2.0 or later"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 from picard.script import register_script_function

--- a/plugins/non_ascii_equivalents/non_ascii_equivalents.py
+++ b/plugins/non_ascii_equivalents/non_ascii_equivalents.py
@@ -19,9 +19,9 @@ from picard import metadata
 
 PLUGIN_NAME = "Non-ASCII Equivalents"
 PLUGIN_AUTHOR = "Anderson Mesquita <andersonvom@trysometinghere>"
-PLUGIN_VERSION = "0.1"
+PLUGIN_VERSION = "0.2"
 PLUGIN_API_VERSIONS = ["0.9", "0.10", "0.11", "0.15", "2.0"]
-PLUGIN_LICENSE = "GPLv3"
+PLUGIN_LICENSE = "GPL-3.0-or-later"
 PLUGIN_LICENSE_URL = "https://gnu.org/licenses/gpl.html"
 PLUGIN_DESCRIPTION = '''Replaces accented and otherwise non-ASCII characters
 with a somewhat equivalent version of their ASCII counterparts. This allows old

--- a/plugins/padded/padded.py
+++ b/plugins/padded/padded.py
@@ -8,7 +8,7 @@ tags."""
 PLUGIN_VERSION = "1.0"
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0",
                        "1.3.0", "2.0", ]
-PLUGIN_LICENSE = "GPL-2.0 or later"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 from picard.metadata import register_track_metadata_processor

--- a/plugins/papercdcase/papercdcase.py
+++ b/plugins/papercdcase/papercdcase.py
@@ -20,9 +20,9 @@
 PLUGIN_NAME = 'Paper CD case'
 PLUGIN_AUTHOR = 'Philipp Wolfer, Sambhav Kothari'
 PLUGIN_DESCRIPTION = 'Create a paper CD case from an album or cluster using http://papercdcase.com'
-PLUGIN_VERSION = "1.1"
+PLUGIN_VERSION = "1.2"
 PLUGIN_API_VERSIONS = ["2.0"]
-PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 

--- a/plugins/playlist/playlist.py
+++ b/plugins/playlist/playlist.py
@@ -16,9 +16,9 @@ PLUGIN_AUTHOR = "Francis Chin, Sambhav Kothari"
 PLUGIN_DESCRIPTION = """Generate an Extended M3U playlist (.m3u8 file, UTF8
 encoded text). Relative pathnames are used where audio files are in the same
 directory as the playlist, otherwise absolute (full) pathnames are used."""
-PLUGIN_VERSION = "1.0"
+PLUGIN_VERSION = "1.1"
 PLUGIN_API_VERSIONS = ["2.0"]
-PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 import os.path

--- a/plugins/reorder_sides/reorder_sides.py
+++ b/plugins/reorder_sides/reorder_sides.py
@@ -28,9 +28,9 @@ PLUGIN_DESCRIPTION = """\
   changers
   (https://en.wikipedia.org/wiki/Record_changer#Automatic_sequencing)
   play in the correct order."""
-PLUGIN_VERSION = '1.0'
+PLUGIN_VERSION = '1.1'
 PLUGIN_API_VERSIONS = ['2.0']
-PLUGIN_LICENSE = 'GPL-3.0'
+PLUGIN_LICENSE = 'GPL-3.0-or-later'
 PLUGIN_LICENSE_URL = 'https://www.gnu.org/licenses/gpl-3.0.html'
 
 import collections

--- a/plugins/save_and_rewrite_header/save_and_rewrite_header.py
+++ b/plugins/save_and_rewrite_header/save_and_rewrite_header.py
@@ -23,9 +23,9 @@ from __future__ import unicode_literals
 PLUGIN_NAME = "Save and rewrite header"
 PLUGIN_AUTHOR = "Nicolas Cenerario"
 PLUGIN_DESCRIPTION = "This plugin adds a context menu action to save files and rewrite their header."
-PLUGIN_VERSION = "0.2"
+PLUGIN_VERSION = "0.3"
 PLUGIN_API_VERSIONS = ["0.9.0", "0.10", "0.15", "2.0"]
-PLUGIN_LICENSE = "GPL-3.0"
+PLUGIN_LICENSE = "GPL-3.0-or-later"
 PLUGIN_LICENSE_URL = "http://www.gnu.org/licenses/gpl-3.0.txt"
 
 from _functools import partial

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -29,7 +29,7 @@ e.g. The Beatles feat. The Who.
 """
 PLUGIN_VERSION = "0.3"
 PLUGIN_API_VERSIONS = ["2.0"]
-PLUGIN_LICENSE = "GPL-3.0"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-3.0.html"
 
 import re, unicodedata

--- a/plugins/sort_multivalue_tags/sort_multivalue_tags.py
+++ b/plugins/sort_multivalue_tags/sort_multivalue_tags.py
@@ -23,9 +23,9 @@ Note: Some multi-value tags are excluded for the following reasons:
 <li>The sequence of one tag is linked to the sequence of another e.g. Label and Catalogue number.</li>
 </ol>
 '''
-PLUGIN_VERSION = "0.3"
+PLUGIN_VERSION = "0.4"
 PLUGIN_API_VERSIONS = ["0.15", "2.0"]
-PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 from picard.metadata import register_track_metadata_processor

--- a/plugins/videotools/__init__.py
+++ b/plugins/videotools/__init__.py
@@ -20,9 +20,9 @@
 PLUGIN_NAME = 'Video tools'
 PLUGIN_AUTHOR = 'Philipp Wolfer'
 PLUGIN_DESCRIPTION = 'Improves the video support in Picard by adding support for Matroska, WebM, AVI, QuickTime and MPEG files (renaming and fingerprinting only, no tagging) and providing $is_audio() and $is_video() scripting functions.'
-PLUGIN_VERSION = "0.2"
+PLUGIN_VERSION = "0.3"
 PLUGIN_API_VERSIONS = ["1.3.0", "2.0"]
-PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 from picard.formats import register_format


### PR DESCRIPTION
Clarify the license by setting it explicit to "GPL-2.0-or-later" or "GPL-3.0-or-later" where this applies. Also unify the spelling of these licenses by ussing the [SPDX name](https://spdx.org/licenses/)

This is not a license change, the affected plugins clearly specify the respective license in their headers. We were just sloppy with the `PLUGIN_LICENSE` value in the past and not as explicit as we should have been. There are also a couple of plugins explicitly having only GPL-2.0 in their headers (both acousticbrainz plugins), the rest does not specify it exactly.