### PR TITLE
cuesheet: Deal with strict str & bytes incompatibility on Python 3

### DIFF
--- a/plugins/cuesheet/cuesheet.py
+++ b/plugins/cuesheet/cuesheet.py
@@ -136,7 +136,7 @@ class Cuesheet(object):
                 line2 = " ".join([self.quote(s) for s in line])
                 line2 = " " * indent + line2 + "\n"
                 lines.append(line2.encode("UTF-8"))
-        with open(encode_filename(self.filename), "wt") as f:
+        with open(encode_filename(self.filename), "wb") as f:
             f.writelines(lines)
 
 

--- a/plugins/cuesheet/cuesheet.py
+++ b/plugins/cuesheet/cuesheet.py
@@ -134,7 +134,8 @@ class Cuesheet(object):
                     elif line[0] != "FILE":
                         indent = 4
                 line2 = " ".join([self.quote(s) for s in line])
-                lines.append(" " * indent + line2.encode("UTF-8") + "\n")
+                line2 = " " * indent + line2 + "\n"
+                lines.append(line2.encode("UTF-8"))
         with open(encode_filename(self.filename), "wt") as f:
             f.writelines(lines)
 


### PR DESCRIPTION
The commit messages have more details. I have tested this with the release from #186 and some other releases with non-ASCII characters.

Fixes #186 