### PR TITLE
Add artist_variables plugin

### DIFF
--- a/plugins/artist_variables/__init__.py
+++ b/plugins/artist_variables/__init__.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Bob Swift (rdswift)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+PLUGIN_NAME = 'Artist Variables'
+PLUGIN_AUTHOR = 'Bob Swift (rdswift)'
+PLUGIN_DESCRIPTION = '''
+This plugin provides specialized album and track variables for use in
+naming scripts. It combines the functionality of the "Album Artist
+Extension" and "RDS Naming Variables" plugins, although the variables
+are provided with different names.  This will require changes to existing
+scripts that used these previous plugins.
+<br /><br />
+The variables provided are:
+<br /><br />
+<strong>Album Variables</strong>
+<ul>
+<li><strong><i>_PriAArtistID</i></strong> - The ID of the primary / first album artist listed
+<li><strong><i>_PriAArtistStd</i></strong> - The primary / first album artist listed (standardized)
+<li><strong><i>_PriAArtistCred</i></strong> - The primary / first album artist listed (as credited)
+<li><strong><i>_PriAArtistSort</i></strong> - The primary / first album artist listed (sort name)
+<li><strong><i>_AdditionalAArtistID</i></strong> - The IDs of all album artists listed except for the primary / first artist, separated by a semicolon and space
+<li><strong><i>_AdditionalAArtistStd</i></strong> - All album artists listed (standardized) except for the primary / first artist, separated with strings provided from the release entry
+<li><strong><i>_AdditionalAArtistCred</i></strong> - All album artists listed (as credited) except for the primary / first artist, separated with strings provided from the release entry
+<li><strong><i>_FullAArtistStd</i></strong> - All album artists listed (standardized), separated with strings provided from the release entry
+<li><strong><i>_FullAArtistCred</i></strong> - All album artists listed (as credited), separated with strings provided from the release entry
+<li><strong><i>_FullAArtistSort</i></strong> - All album artists listed (sort names), separated with strings provided from the release entry
+<li><strong><i>_FullAArtistPriSort</i></strong> - The primary / first album artist listed (sort name) followed by all additional album artists (standardized), separated with strings provided from the release entry
+<li><strong><i>_AArtistCount</i></strong> - The number of artists listed as album artists
+</ul><br />
+<strong>Track Variables</strong>
+<ul>
+<li><strong><i>_PriTArtistID</i></strong> - The ID of the primary / first track artist listed
+<li><strong><i>_PriTArtistStd</i></strong> - The primary / first track artist listed (standardized)
+<li><strong><i>_PriTArtistCred</i></strong> - The primary / first track artist listed (as credited)
+<li><strong><i>_PriTArtistSort</i></strong> - The primary / first track artist listed (sort name)
+<li><strong><i>_AdditionalTArtistID</i></strong> - The IDs of all track artists listed except for the primary / first artist, separated by a semicolon and space
+<li><strong><i>_AdditionalTArtistStd</i></strong> - All track artists listed (standardized) except for the primary / first artist, separated with strings provided from the track entry
+<li><strong><i>_AdditionalTArtistCred</i></strong> - All track artists listed (as credited) except for the primary / first artist, separated with strings provided from the track entry
+<li><strong><i>_FullTArtistStd</i></strong> - All track artists listed (standardized), separated with strings provided from the track entry
+<li><strong><i>_FullTArtistCred</i></strong> - All track artists listed (as credited), separated with strings provided from the track entry
+<li><strong><i>_FullTArtistSort</i></strong> - All track artists listed (sort names), separated with strings provided from the track entry
+<li><strong><i>_FullTArtistPriSort</i></strong> - The primary / first track artist listed (sort name) followed by all additional track artists (standardized), separated with strings provided from the track entry
+<li><strong><i>_TArtistCount</i></strong> - The number of artists listed as track artists
+</ul><br />
+<strong>PLEASE NOTE</strong>: Tagger scripts are required to make use of these hidden
+variables.
+<br /><br />
+Please see the <a href="https://github.com/rdswift/picard-plugins/blob/2.0_RDS_Plugins/plugins/artist_variables/docs/README.md">user guide</a> on GitHub for more information.
+'''
+
+PLUGIN_VERSION = "0.3"
+PLUGIN_API_VERSIONS = ["2.0", "2.1"]
+PLUGIN_LICENSE = "GPL-2.0-or-later"
+PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
+
+PLUGIN_USER_GUIDE_URL = "https://github.com/rdswift/picard-plugins/blob/2.0_RDS_Plugins/plugins/artist_variables/docs/README.md"
+
+from picard import config, log
+from picard.metadata import (register_album_metadata_processor,
+                             register_track_metadata_processor)
+from picard.plugin import PluginPriority
+
+
+def process_artists(album_id, source_metadata, destination_metadata, source_type):
+    metadata_type = 'release' if source_type == 'A' else 'track'
+    # Test for valid metadata node for the release
+    # The 'artist-credit' key should always be there.
+    # This check is to avoid a runtime error if it doesn't exist for some reason.
+    if 'artist-credit' in source_metadata:
+        # Initialize variables to default values
+        sort_pri_artist = ""
+        std_artist = ""
+        cred_artist = ""
+        sort_artist = ""
+        additional_std_artist = ""
+        additional_cred_artist = ""
+        artist_count = 0
+        additional_artist_ids = []
+        for artist_credit in source_metadata['artist-credit']:
+            # Initialize temporary variables for each loop.
+            temp_std_name = ""
+            temp_cred_name = ""
+            temp_sort_name = ""
+            temp_phrase = ""
+            temp_id = ""
+            # Check if there is a 'joinphrase' specified.
+            if 'joinphrase' in artist_credit:
+                temp_phrase = artist_credit['joinphrase']
+            else:
+                metadata_error(album_id, 'artist-credit.joinphrase', metadata_type)
+            # Check if there is a 'name' specified.
+            if 'name' in artist_credit:
+                temp_cred_name = artist_credit['name']
+            else:
+                metadata_error(album_id, 'artist-credit.name', metadata_type)
+            # Check if there is an 'artist' specified.
+            if 'artist' in artist_credit:
+                # Check if there is an 'id' specified.
+                if 'id' in artist_credit['artist']:
+                    temp_id = artist_credit['artist']['id']
+                else:
+                    metadata_error(album_id, 'artist-credit.artist.id', metadata_type)
+                # Check if there is a 'name' specified.
+                if 'name' in artist_credit['artist']:
+                    temp_std_name = artist_credit['artist']['name']
+                else:
+                    metadata_error(album_id, 'artist-credit.artist.name', metadata_type)
+                if 'sort-name' in artist_credit['artist']:
+                    temp_sort_name = artist_credit['artist']['sort-name']
+                else:
+                    metadata_error(album_id, 'artist-credit.artist.sort-name', metadata_type)
+            else:
+                metadata_error(album_id, 'artist-credit.artist', metadata_type)
+            std_artist += temp_std_name + temp_phrase
+            cred_artist += temp_cred_name + temp_phrase
+            sort_artist += temp_sort_name + temp_phrase
+            if artist_count < 1:
+                if temp_id:
+                    destination_metadata["~Pri{0}ArtistID".format(source_type,)] = temp_id
+                destination_metadata["~Pri{0}ArtistStd".format(source_type,)] = temp_std_name
+                destination_metadata["~Pri{0}ArtistCred".format(source_type,)] = temp_cred_name
+                destination_metadata["~Pri{0}ArtistSort".format(source_type,)] = temp_sort_name
+                sort_pri_artist += temp_sort_name + temp_phrase
+            else:
+                if temp_id:
+                    additional_artist_ids.append(temp_id,)
+                sort_pri_artist += temp_std_name + temp_phrase
+                additional_std_artist += temp_std_name + temp_phrase
+                additional_cred_artist += temp_cred_name + temp_phrase
+            artist_count += 1
+    else:
+        metadata_error(album_id, 'artist-credit', metadata_type)
+    if additional_artist_ids:
+        destination_metadata["~Additional{0}ArtistID".format(source_type,)] = "; ".join(additional_artist_ids)
+    if std_artist:
+        destination_metadata["~Full{0}ArtistStd".format(source_type,)] = std_artist
+    if cred_artist:
+        destination_metadata["~Full{0}ArtistCred".format(source_type,)] = cred_artist
+    if additional_std_artist:
+        destination_metadata["~Additional{0}ArtistStd".format(source_type,)] = additional_std_artist
+    if additional_cred_artist:
+        destination_metadata["~Additional{0}ArtistCred".format(source_type,)] = additional_cred_artist
+    if sort_pri_artist:
+        destination_metadata["~Full{0}ArtistPriSort".format(source_type,)] = sort_pri_artist
+    if sort_artist:
+        destination_metadata["~Full{0}ArtistSort".format(source_type,)] = sort_artist
+    if artist_count:
+        destination_metadata["~{0}ArtistCount".format(source_type,)] = artist_count
+    return None
+
+
+def make_album_vars(album, album_metadata, release_metadata):
+    album_id = release_metadata['id'] if release_metadata else 'No Album ID'
+    process_artists(album_id, release_metadata, album_metadata, 'A')
+    return None
+
+
+def make_track_vars(album, album_metadata, track_metadata, release_metadata):
+    album_id = release_metadata['id'] if release_metadata else 'No Album ID'
+    process_artists(album_id, track_metadata, album_metadata, 'T')
+    return None
+
+
+def metadata_error(album_id, metadata_element, metadata_group):
+    log.error("%s: %r: Missing '%s' in %s metadata.",
+            PLUGIN_NAME, album_id, metadata_element, metadata_group)
+
+
+# Register the plugin to run at a LOW priority so that other plugins that
+# modify the artist information can complete their processing and this plugin
+# is working with the latest updated data.
+register_album_metadata_processor(make_album_vars, priority=PluginPriority.LOW)
+register_track_metadata_processor(make_track_vars, priority=PluginPriority.LOW)

--- a/plugins/artist_variables/docs/HISTORY.md
+++ b/plugins/artist_variables/docs/HISTORY.md
@@ -1,0 +1,30 @@
+# Artist Variables
+
+## Contributors
+
+The following people have contributed to the development of this plugin.
+
+* Bob Swift ([rdswift](https://github.com/rdswift/))
+
+---
+
+## Revision History
+
+The following identifies the development history of the plugin, in reverse chronological order.  Each version lists the changes made for that version, along with the author of each change.
+
+### Version 0.3
+
+* Refactor duplicated code to new method \[rdswift\]
+
+### Version 0.2
+
+* Add `PLUGIN_USER_GUIDE_URL` constant \[rdswift\]
+* Add "2.1" to `PLUGIN_API_VERSIONS` \[rdswift\]
+* Add missing argument in call to `metadata_error logger` \[rdswift\]
+* Add `HISTORY.md` file \[rdswift\]
+
+### Version 0.1
+
+* Initial testing release \[rdswift\]
+
+---

--- a/plugins/artist_variables/docs/README.md
+++ b/plugins/artist_variables/docs/README.md
@@ -1,0 +1,158 @@
+# Artist Variables \[[Download](https://github.com/rdswift/picard-plugins/raw/2.0_RDS_Plugins/plugins/artist_variables/artist_variables.zip)\]
+
+## Overview
+
+This plugin provides specialized album and track variables for use in naming scripts. It combines the
+functionality of the "Album Artist Extension" and "RDS Naming Variables" plugins, although the variables
+are provided with different names.  This will require changes to existing scripts when switching from the
+previous plugins.
+
+---
+
+## What it Does
+
+This plugin reads the album and track metadata provided to Picard and exposes the information in a number
+of additional variables for use in Picard scripts.  The plugin has been designed such that the information
+is presented consistently regardless of whether or not the `Use standardized artist names` option is selected.
+This means that some of the information available through the standard Picard tags will be duplicated in the
+variables provided by this plugin.
+
+***NOTE:*** There are no additional calls to the MusicBrainz website api for additional information.
+
+### Album Variables
+
+* **_PriAArtistID** - The ID of the primary / first album artist listed
+* **_PriAArtistStd** - The primary / first album artist listed (standardized)
+* **_PriAArtistCred** - The primary / first album artist listed (as credited)
+* **_PriAArtistSort** - The primary / first album artist listed (sort name)
+* **_AdditionalAArtistID** - The IDs of all album artists listed except for the primary / first artist, separated by a semicolon and space
+* **_AdditionalAArtistStd** - All album artists listed (standardized) except for the primary / first artist, separated with strings provided from the release entry
+* **_AdditionalAArtistCred** - All album artists listed (as credited) except for the primary / first artist, separated with strings provided from the release entry
+* **_FullAArtistStd** - All album artists listed (standardized), separated with strings provided from the release entry
+* **_FullAArtistCred** - All album artists listed (as credited), separated with strings provided from the release entry
+* **_FullAArtistSort** - All album artists listed (sort names), separated with strings provided from the release entry
+* **_FullAArtistPriSort** - The primary / first album artist listed (sort name) followed by all additional album artists (standardized), separated with strings provided from the release entry
+* **_AArtistCount** - The number of artists listed as album artists
+
+### Track Variables
+
+* **_PriTArtistID** - The ID of the primary / first track artist listed
+* **_PriTArtistStd** - The primary / first track artist listed (standardized)
+* **_PriTArtistCred** - The primary / first track artist listed (as credited)
+* **_PriTArtistSort** - The primary / first track artist listed (sort name)
+* **_AdditionalTArtistID** - The IDs of all track artists listed except for the primary / first artist, separated by a semicolon and space
+* **_AdditionalTArtistStd** - All track artists listed (standardized) except for the primary / first artist, separated with strings provided from the track entry
+* **_AdditionalTArtistCred** - All track artists listed (as credited) except for the primary / first artist, separated with strings provided from the track entry
+* **_FullTArtistStd** - All track artists listed (standardized), separated with strings provided from the track entry
+* **_FullTArtistCred** - All track artists listed (as credited), separated with strings provided from the track entry
+* **_FullTArtistSort** - All track artists listed (sort names), separated with strings provided from the track entry
+* **_FullTArtistPriSort** - The primary / first track artist listed (sort name) followed by all additional track artists (standardized), separated with strings provided from the track entry
+* **_TArtistCount** - The number of artists listed as track artists
+
+---
+
+## Examples
+
+The following are some examples using actual information from MusicBrainz:
+
+### Example 1:
+
+Using the single "[Fairytale of New York](https://musicbrainz.org/release/e428018c-5536-47f7-aca7-581e748b6fd5)"
+by [Walk Off The Earth](https://musicbrainz.org/artist/e2a5eaeb-7de7-4ffe-a519-e18e427a5060) (credited as
+"Gianni and Sarah"), the additional artist variables created are:
+
+* **_PriAArtistID** = e2a5eaeb-7de7-4ffe-a519-e18e427a5060
+* **_PriAArtistStd** = Walk Off The Earth
+* **_PriAArtistCred** = Gianni and Sarah
+* **_PriAArtistSort** = Walk Off The Earth
+* **_FullAArtistStd** = Walk Off The Earth
+* **_FullAArtistCred** = Gianni and Sarah
+* **_FullAArtistSort** = Walk Off The Earth
+* **_FullAArtistPriSort** = Walk Off The Earth
+* **_AArtistCount** = 1
+* **_PriTArtistID** = e2a5eaeb-7de7-4ffe-a519-e18e427a5060
+* **_PriTArtistStd** = Walk Off The Earth
+* **_PriTArtistCred** = Gianni and Sarah
+* **_PriTArtistSort** = Walk Off The Earth
+* **_FullTArtistStd** = Walk Off The Earth
+* **_FullTArtistCred** = Gianni and Sarah
+* **_FullTArtistSort** = Walk Off The Earth
+* **_FullTArtistPriSort** = Walk Off The Earth
+* **_TArtistCount** = 1
+
+Because there is only one artist associated with this single, the **_AdditionalAArtistID**, **_AdditionalAArtistStd**, 
+**_AdditionalAArtistCred**, **_AdditionalTArtistID**, **_AdditionalTArtistStd** and **_AdditionalTArtistCred** variables
+are not created.
+
+
+### Example 2:
+
+Using the single "[Wrecking Ball](https://musicbrainz.org/release/8c759d7a-2ade-4201-abc2-a2a7c1a6ad6c)" by
+[Sarah Blackwood](https://musicbrainz.org/artist/af7e5ea9-bd58-4346-8f78-d672e9f297f7),
+[Jenni Pleau](https://musicbrainz.org/artist/07fa21a9-c253-4ed0-b711-d63f7965b723) &
+[Emily Bones](https://musicbrainz.org/artist/541d331c-f041-4895-b8f2-7db9e27dc5ab), the additional artist variables
+created are:
+
+* **_PriAArtistID** = af7e5ea9-bd58-4346-8f78-d672e9f297f7
+* **_PriAArtistStd** = Sarah Blackwood
+* **_PriAArtistCred** = Sarah Blackwood
+* **_PriAArtistSort** = Blackwood, Sarah
+* **_AdditionalAArtistID** = 07fa21a9-c253-4ed0-b711-d63f7965b723; 541d331c-f041-4895-b8f2-7db9e27dc5ab
+* **_AdditionalAArtistStd** = Jenni Pleau & Emily Bones
+* **_AdditionalAArtistCred** = Jenni Pleau & Emily Bones
+* **_FullAArtistStd** = Sarah Blackwood, Jenni Pleau & Emily Bones
+* **_FullAArtistCred** = Sarah Blackwood, Jenni Pleau & Emily Bones
+* **_FullAArtistSort** = Blackwood, Sarah, Pleau, Jenni & Bones, Emily
+* **_FullAArtistPriSort** = Blackwood, Sarah, Jenni Pleau & Emily Bones
+* **_AArtistCount** = 3
+* **_PriTArtistID** = af7e5ea9-bd58-4346-8f78-d672e9f297f7
+* **_PriTArtistStd** = Sarah Blackwood
+* **_PriTArtistCred** = Sarah Blackwood
+* **_PriTArtistSort** = Blackwood, Sarah
+* **_AdditionalTArtistID** = 07fa21a9-c253-4ed0-b711-d63f7965b723; 541d331c-f041-4895-b8f2-7db9e27dc5ab
+* **_AdditionalTArtistStd** = Jenni Pleau & Emily Bones
+* **_AdditionalTArtistCred** = Jenni Pleau & Emily Bones
+* **_FullTArtistStd** = Sarah Blackwood, Jenni Pleau & Emily Bones
+* **_FullTArtistCred** = Sarah Blackwood, Jenni Pleau & Emily Bones
+* **_FullTArtistSort** = Blackwood, Sarah, Pleau, Jenni & Bones, Emily
+* **_FullTArtistPriSort** = Blackwood, Sarah, Jenni Pleau & Emily Bones
+* **_TArtistCount** = 3
+
+Because there are multiple artists associated with both the album and the track, all artist variables are created.
+
+### Example 3:
+
+Using the album "[Kermit Unpigged](https://musicbrainz.org/release/860fd92f-6899-4b31-a205-d6b746da734e)" by
+[The Muppets](https://musicbrainz.org/artist/2ca340a6-e8f2-489d-90c2-f37c5c802d49), the additional artist variables
+created for track 4, "[All I Have to Do Is Dream](https://musicbrainz.org/recording/5d98e4d4-be42-4412-94ad-f19562faa416)"
+by [Linda Ronstadt](https://musicbrainz.org/artist/498f2581-be21-4eef-8756-fbb89d79b1c0) and
+[Kermit the Frog](https://musicbrainz.org/artist/992a7ea8-96c1-4058-ba96-f811c8d01c77), are:
+
+
+* **_PriAArtistID** = 2ca340a6-e8f2-489d-90c2-f37c5c802d49
+* **_PriAArtistStd** = The Muppets
+* **_PriAArtistCred** = The Muppets
+* **_PriAArtistSort** = Muppets, The
+* **_FullAArtistStd** = The Muppets
+* **_FullAArtistCred** = The Muppets
+* **_FullAArtistSort** = Muppets, The
+* **_FullAArtistPriSort** = Muppets, The
+* **_AArtistCount** = 1
+
+### Track Variables
+
+* **_PriTArtistID** = 498f2581-be21-4eef-8756-fbb89d79b1c0
+* **_PriTArtistStd** = Linda Ronstadt
+* **_PriTArtistCred** = Linda Ronstadt
+* **_PriTArtistSort** = Ronstadt, Linda
+* **_AdditionalTArtistID** = 992a7ea8-96c1-4058-ba96-f811c8d01c77
+* **_AdditionalTArtistStd** = Kermit the Frog
+* **_AdditionalTArtistCred** = Kermit the Frog
+* **_FullTArtistStd** = Linda Ronstadt and Kermit the Frog
+* **_FullTArtistCred** = Linda Ronstadt and Kermit the Frog
+* **_FullTArtistSort** = Ronstadt, Linda and Kermit the Frog
+* **_FullTArtistPriSort** = Ronstadt, Linda and Kermit the Frog
+* **_TArtistCount** = 2
+
+Because there is only one artist associated with the album the **_AdditionalAArtistID**, **_AdditionalAArtistStd** and
+**_AdditionalAArtistCred** variables are not created.


### PR DESCRIPTION
Add new plugin to (eventually) replace the ***album_artist_extension*** plugin, as discussed in the [community forum](https://community.metabrainz.org/t/artist-variables-plugin/409544/2).  This new plugin provides the same functionality (and more), but the new tag variable names have changed.