### PR TITLE
Enable doctests for addrelease.py again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+before_install:
+  - pip3 install picard
 script: python test.py

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+import doctest
 import os
 import glob
 import json
@@ -85,6 +86,12 @@ class GenerateTestCase(unittest.TestCase):
             self.assertIsInstance(data['author'], str)
             self.assertIsInstance(data['description'], str)
             self.assertIsInstance(data['version'], str)
+
+
+def load_tests(loader, tests, ignore):
+    from plugins.addrelease import addrelease
+    tests.addTests(doctest.DocTestSuite(addrelease))
+    return tests
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverts commit a63ff909135072cdcb6ffe3688c537b13c12598f.

Picard 2.1 can be installed & imported from PyPI.