### PR TITLE
Update usage of track_metadata_processor

### DIFF
--- a/plugins/acousticbrainz/acousticbrainz.py
+++ b/plugins/acousticbrainz/acousticbrainz.py
@@ -23,7 +23,7 @@ PLUGIN_DESCRIPTION = '''Uses AcousticBrainz for mood and genre.
 WARNING: Experimental plugin. All guarantees voided by use.'''
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = "1.2.0"
+PLUGIN_VERSION = "1.2.1"
 PLUGIN_API_VERSIONS = ["2.0"]
 
 from functools import partial
@@ -66,7 +66,7 @@ def result(album, metadata, data, reply, error):
         album._finalize_loading(None)
 
 
-def process_track(album, metadata, release, track):
+def process_track(album, metadata, track, release):
     queryargs = {
         "recording_ids": metadata["musicbrainz_recordingid"],
         "map_classes": "true"

--- a/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
+++ b/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
@@ -27,7 +27,7 @@ from the AcousticBrainz database.<br/><br/>
 '''
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = '1.1.2'
+PLUGIN_VERSION = '1.1.3'
 PLUGIN_API_VERSIONS = ["2.0"]  # Requires support for TKEY which is in 1.4
 
 from json import JSONDecodeError
@@ -46,7 +46,7 @@ ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 50)
 
 class AcousticBrainz_Key:
 
-    def get_data(self, album, track_metadata, trackXmlNode, releaseXmlNode):
+    def get_data(self, album, track_metadata, track_node, release_node):
         if "musicbrainz_recordingid" not in track_metadata:
             log.error("%s: Error parsing response. No MusicBrainz recording id found.",
                       PLUGIN_NAME)

--- a/plugins/albumartist_website/albumartist_website.py
+++ b/plugins/albumartist_website/albumartist_website.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = 'Album Artist Website'
 PLUGIN_AUTHOR = 'Sophist, Sambhav Kothari'
 PLUGIN_DESCRIPTION = '''Add's the album artist(s) Official Homepage(s)
 (if they are defined in the MusicBrainz database).'''
-PLUGIN_VERSION = '1.0'
+PLUGIN_VERSION = '1.0.1'
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -64,7 +64,7 @@ class AlbumArtistWebsite:
         self.website_cache = {}
         self.website_queue = self.ArtistWebsiteQueue()
 
-    def add_artist_website(self, album, track_metadata, trackXmlNode, releaseXmlNode):
+    def add_artist_website(self, album, track_metadata, track_node, release_node):
         albumArtistIds = dict.get(track_metadata,'musicbrainz_albumartistid', [])
         for artistId in albumArtistIds:
             if artistId in self.website_cache:

--- a/plugins/classicdiscnumber/classicdiscnumber.py
+++ b/plugins/classicdiscnumber/classicdiscnumber.py
@@ -1,14 +1,14 @@
 PLUGIN_NAME = 'Classic Disc Numbers'
 PLUGIN_AUTHOR = 'Lukas Lalinsky'
 PLUGIN_DESCRIPTION = '''Moves disc numbers and subtitles from the separate tags to album titles.'''
-PLUGIN_VERSION = "0.1"
+PLUGIN_VERSION = "0.2"
 PLUGIN_API_VERSIONS = ["0.15", "2.0"]
 
 from picard.metadata import register_track_metadata_processor
 import re
 
 
-def add_discnumbers(tagger, metadata, release, track):
+def add_discnumbers(tagger, metadata, track, release):
     if int(metadata["totaldiscs"] or "0") > 1:
         if "discsubtitle" in metadata:
             metadata["album"] = "%s (disc %s: %s)" % (

--- a/plugins/featartist/featartist.py
+++ b/plugins/featartist/featartist.py
@@ -1,7 +1,7 @@
 PLUGIN_NAME = 'Feat. Artists Removed'
 PLUGIN_AUTHOR = 'Lukas Lalinsky, Bryan Toth'
 PLUGIN_DESCRIPTION = 'Removes feat. artists from track titles.  Substitution is case insensitive.'
-PLUGIN_VERSION = "0.3"
+PLUGIN_VERSION = "0.4"
 PLUGIN_API_VERSIONS = ["0.9.0", "0.10", "0.15", "0.16", "2.0"]
 
 from picard.metadata import register_track_metadata_processor
@@ -10,7 +10,7 @@ import re
 _feat_re = re.compile(r"\s+\(feat\. [^)]*\)", re.IGNORECASE)
 
 
-def remove_featartists(tagger, metadata, release, track):
+def remove_featartists(tagger, metadata, track, release):
     metadata["title"] = _feat_re.sub("", metadata["title"])
 
 register_track_metadata_processor(remove_featartists)

--- a/plugins/featartistsintitles/featartistsintitles.py
+++ b/plugins/featartistsintitles/featartistsintitles.py
@@ -1,7 +1,7 @@
 PLUGIN_NAME = 'Feat. Artists in Titles'
 PLUGIN_AUTHOR = 'Lukas Lalinsky, Michael Wiencek, Bryan Toth, JeromyNix (NobahdiAtoll)'
 PLUGIN_DESCRIPTION = 'Move "feat." from artist names to album and track titles. Match is case insensitive.'
-PLUGIN_VERSION = "0.4"
+PLUGIN_VERSION = "0.5"
 PLUGIN_API_VERSIONS = ["0.9.0", "0.10", "0.15", "0.16", "2.0"]
 
 from picard.metadata import register_album_metadata_processor, register_track_metadata_processor
@@ -20,7 +20,7 @@ def move_album_featartists(tagger, metadata, release):
         metadata["albumartistsort"] = match.group(1)
 
 
-def move_track_featartists(tagger, metadata, release, track):
+def move_track_featartists(tagger, metadata, track, release):
     match = _feat_re.match(metadata["artist"])
     if match:
         metadata["artist"] = match.group(1)

--- a/plugins/hyphen_unicode/hyphen_unicode.py
+++ b/plugins/hyphen_unicode/hyphen_unicode.py
@@ -20,7 +20,7 @@ from picard import metadata
 
 PLUGIN_NAME = "Hyphen unicode"
 PLUGIN_AUTHOR = "Alan Swanson <revier@improbability.net>"
-PLUGIN_VERSION = "1.0"
+PLUGIN_VERSION = "1.0.1"
 PLUGIN_API_VERSIONS = ["0.9", "0.10", "0.11", "0.15", "2.0"]
 PLUGIN_LICENSE = "GPL-3.0-or-later"
 PLUGIN_LICENSE_URL = "https://gnu.org/licenses/gpl.html"
@@ -30,7 +30,7 @@ that do not support HYPHEN and to prevent visually duplicate filenames
 differentiated only by their hyphens.
 
 Unicode duplicated hyphen from ASCII as an unambiguous way to designate a
-hyphen from a minus whilst still being typographically indentical. Since 
+hyphen from a minus whilst still being typographically indentical. Since
 text processing on music tags is rare so choice is purely pedantic esepcially
 as keyboards only have HYPHEN-MINUS.
 
@@ -69,7 +69,7 @@ def ascii(word):
     return "".join(sanitize(char) for char in word)
 
 
-def main(tagger, metadata, release, track=None):
+def main(tagger, metadata, *args):
     for name, value in metadata.rawitems():
         if name in FILTER_TAGS:
             metadata[name] = [ascii(x) for x in value]

--- a/plugins/lastfm/__init__.py
+++ b/plugins/lastfm/__init__.py
@@ -3,7 +3,7 @@
 PLUGIN_NAME = 'Last.fm'
 PLUGIN_AUTHOR = 'Lukáš Lalinský, Philipp Wolfer'
 PLUGIN_DESCRIPTION = 'Use tags from Last.fm as genre.'
-PLUGIN_VERSION = "0.9"
+PLUGIN_VERSION = "0.10"
 PLUGIN_API_VERSIONS = ["2.0"]
 
 import re
@@ -181,7 +181,7 @@ def get_artist_tags(album, metadata, artist, min_usage,
     get_tags(album, metadata, queryargs, min_usage, ignore, next_, current)
 
 
-def process_track(album, metadata, release, track):
+def process_track(album, metadata, track, release):
     use_track_tags = config.setting["lastfm_use_track_tags"]
     use_artist_tags = config.setting["lastfm_use_artist_tags"]
     min_tag_usage = config.setting["lastfm_min_tag_usage"]

--- a/plugins/musixmatch/__init__.py
+++ b/plugins/musixmatch/__init__.py
@@ -1,7 +1,7 @@
 PLUGIN_NAME = 'Musixmatch Lyrics'
 PLUGIN_AUTHOR = 'm-yn, Sambhav Kothari, Philipp Wolfer'
 PLUGIN_DESCRIPTION = 'Fetch first 30% of lyrics from Musixmatch'
-PLUGIN_VERSION = '1.1'
+PLUGIN_VERSION = '1.1.1'
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -41,7 +41,7 @@ def handle_result(album, metadata, data, reply, error):
         album._finalize_loading(error)
 
 
-def process_track(album, metadata, release, track):
+def process_track(album, metadata, track, release):
     apikey = config.setting['musixmatch_api_key']
     if not apikey:
         log.warning('MusixMatch: No API key configured')

--- a/plugins/no_release/no_release.py
+++ b/plugins/no_release/no_release.py
@@ -3,7 +3,7 @@
 PLUGIN_NAME = 'No release'
 PLUGIN_AUTHOR = 'Johannes Weißl, Philipp Wolfer'
 PLUGIN_DESCRIPTION = '''Do not store specific release information in releases of unknown origin.'''
-PLUGIN_VERSION = '0.2'
+PLUGIN_VERSION = '0.3'
 PLUGIN_API_VERSIONS = ['2.0']
 
 from PyQt5 import QtCore, QtGui, QtWidgets
@@ -97,17 +97,17 @@ class NoReleaseOptionsPage(OptionsPage):
         config.setting['norelease_enable'] = self.ui.norelease_enable.isChecked()
 
 
-def NoReleaseAlbumProcessor(tagger, metadata, release):
+def no_release_album_processor(tagger, metadata, release):
     if config.setting['norelease_enable']:
         strip_release_specific_metadata(metadata)
 
 
-def NoReleaseTrackProcessor(tagger, metadata, track, release):
+def no_release_track_processor(tagger, metadata, track, release):
     if config.setting['norelease_enable']:
         strip_release_specific_metadata(metadata)
 
 
-register_album_metadata_processor(NoReleaseAlbumProcessor)
-register_track_metadata_processor(NoReleaseTrackProcessor)
+register_album_metadata_processor(no_release_album_processor)
+register_track_metadata_processor(no_release_track_processor)
 register_album_action(NoReleaseAction())
 register_options_page(NoReleaseOptionsPage)

--- a/plugins/non_ascii_equivalents/non_ascii_equivalents.py
+++ b/plugins/non_ascii_equivalents/non_ascii_equivalents.py
@@ -19,7 +19,7 @@ from picard import metadata
 
 PLUGIN_NAME = "Non-ASCII Equivalents"
 PLUGIN_AUTHOR = "Anderson Mesquita <andersonvom@trysometinghere>"
-PLUGIN_VERSION = "0.2"
+PLUGIN_VERSION = "0.3"
 PLUGIN_API_VERSIONS = ["0.9", "0.10", "0.11", "0.15", "2.0"]
 PLUGIN_LICENSE = "GPL-3.0-or-later"
 PLUGIN_LICENSE_URL = "https://gnu.org/licenses/gpl.html"
@@ -141,7 +141,7 @@ def ascii(word):
     return "".join(sanitize(char) for char in word)
 
 
-def main(tagger, metadata, release, track=None):
+def main(tagger, metadata, *args):
     for name, value in metadata.rawitems():
         if name in FILTER_TAGS:
             metadata[name] = [ascii(x) for x in value]

--- a/plugins/padded/padded.py
+++ b/plugins/padded/padded.py
@@ -5,7 +5,7 @@ Adds padded disc- and tracknumbers so the length of all disc- and tracknumbers
 is the same. They are stored in the `_paddedtracknumber` and `_paddeddiscnumber`
 tags."""
 
-PLUGIN_VERSION = "1.0"
+PLUGIN_VERSION = "1.0.1"
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0",
                        "1.3.0", "2.0", ]
 PLUGIN_LICENSE = "GPL-2.0-or-later"
@@ -15,7 +15,7 @@ from picard.metadata import register_track_metadata_processor
 
 
 @register_track_metadata_processor
-def add_padded_tn(album, metadata, release, track):
+def add_padded_tn(album, metadata, track, release):
     maxlength = len(metadata["totaltracks"])
     islength = len(metadata["tracknumber"])
     metadata["~paddedtracknumber"] = (int(maxlength - islength) * "0" +
@@ -23,7 +23,7 @@ def add_padded_tn(album, metadata, release, track):
 
 
 @register_track_metadata_processor
-def add_padded_dn(album, metadata, release, track):
+def add_padded_dn(album, metadata, track, release):
     maxlength = len(metadata["totaldiscs"])
     islength = len(metadata["discnumber"])
     metadata["~paddeddiscnumber"] = (int(maxlength - islength) * "0" +

--- a/plugins/replace_forbidden_symbols/replace_forbidden_symbols.py
+++ b/plugins/replace_forbidden_symbols/replace_forbidden_symbols.py
@@ -20,7 +20,7 @@ from picard.script import register_script_function
 
 PLUGIN_NAME = "Replace Forbidden Symbols"
 PLUGIN_AUTHOR = "Alex Rustler <alex_rustler@rambler.ru>"
-PLUGIN_VERSION = "0.2"
+PLUGIN_VERSION = "0.3"
 PLUGIN_API_VERSIONS = ["0.9", "0.10", "0.11", "0.15", "2.0", "2.2"]
 PLUGIN_LICENSE = "GPL-3.0-or-later"
 PLUGIN_LICENSE_URL = "https://gnu.org/licenses/gpl.html"
@@ -75,7 +75,7 @@ def script_replace_forbidden(parser, value):
     return fix_forbidden(value)
 
 
-def main(tagger, metadata, release, track=None):
+def main(tagger, metadata, *args):
     for name, value in metadata.rawitems():
         if name in FILTER_TAGS:
             metadata[name] = replace_forbidden(value)

--- a/plugins/smart_title_case/smart_title_case.py
+++ b/plugins/smart_title_case/smart_title_case.py
@@ -27,7 +27,7 @@ Leaves words containing embedded uppercase as-is i.e. USA or DoA.<br />
 For Artist/AlbumArtist, title cases only artists not join phrases<br />
 e.g. The Beatles feat. The Who.
 """
-PLUGIN_VERSION = "0.3"
+PLUGIN_VERSION = "0.4"
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-3.0.html"
@@ -105,7 +105,7 @@ from picard.metadata import (
     register_album_metadata_processor,
 )
 
-def title_case(tagger, metadata, release, track=None):
+def title_case(tagger, metadata, *args):
     for name in title_tags:
         if name in metadata:
             values = metadata.getall(name)

--- a/plugins/standardise_feat/standardise_feat.py
+++ b/plugins/standardise_feat/standardise_feat.py
@@ -1,7 +1,7 @@
 PLUGIN_NAME = 'Standardise Feat.'
 PLUGIN_AUTHOR = 'Sambhav Kothari'
 PLUGIN_DESCRIPTION = 'Standardises "featuring" join phrases for artists to "feat."'
-PLUGIN_VERSION = "0.1"
+PLUGIN_VERSION = "0.2"
 PLUGIN_API_VERSIONS = ["1.4", "2.0"]
 PLUGIN_LICENSE = "GPL-3.0"
 PLUGIN_LICENSE_URL = "http://www.gnu.org/licenses/gpl-3.0.txt"
@@ -31,7 +31,7 @@ def standardise_feat(artists_str, artists_list):
                         zip(artists_list, standardised_join_phrases)])
 
 
-def standardise_track_artist(tagger, metadata, release, track):
+def standardise_track_artist(tagger, metadata, track, release):
     metadata["artist"] = standardise_feat(metadata["artist"], metadata.getall("artists"))
     metadata["artistsort"] = standardise_feat(metadata["artistsort"], metadata.getall("~artists_sort"))
 

--- a/plugins/tangoinfo/tangoinfo.py
+++ b/plugins/tangoinfo/tangoinfo.py
@@ -8,7 +8,7 @@ PLUGIN_DESCRIPTION = """
 it does not cause unnecessary server load for either MusicBrainz.org
 or tango.info</p>
 """
-PLUGIN_VERSION = "1.1"
+PLUGIN_VERSION = "1.1.1"
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -82,8 +82,7 @@ class TangoInfoTagger:
         self.albumpage_cache = {}
         self.albumpage_queue = self.TangoInfoScrapeQueue()
 
-    def add_tangoinfo_data(self, album, track_metadata,
-            trackXmlNode, releaseXmlNode):
+    def add_tangoinfo_data(self, album, track_metadata, track, release):
         #log.debug("%s: Track metadata: %s " % (PLUGIN_NAME, track_metadata))
 
         # BARCODE or barcode

--- a/plugins/titlecase/titlecase.py
+++ b/plugins/titlecase/titlecase.py
@@ -8,7 +8,7 @@
 PLUGIN_NAME = "Title Case"
 PLUGIN_AUTHOR = "Javier Kohen, Sambhav Kothari"
 PLUGIN_DESCRIPTION = "Capitalize First Character In Every Word Of A Title"
-PLUGIN_VERSION = "1.0"
+PLUGIN_VERSION = "1.0.1"
 PLUGIN_API_VERSIONS = ['2.0']
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -59,7 +59,7 @@ from picard.metadata import (
 )
 
 
-def title_case(tagger, metadata, release, track=None):
+def title_case(tagger, metadata, *args):
     for name, value in metadata.rawitems():
         if name in ["title", "album", "artist"]:
             metadata[name] = [title(x) for x in value]

--- a/plugins/wikidata/__init__.py
+++ b/plugins/wikidata/__init__.py
@@ -8,7 +8,7 @@
 PLUGIN_NAME = 'Wikidata Genre'
 PLUGIN_AUTHOR = 'Daniel Sobey, Sambhav Kothari'
 PLUGIN_DESCRIPTION = 'query wikidata to get genre tags'
-PLUGIN_VERSION = '1.4'
+PLUGIN_VERSION = '1.4.1'
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = 'WTFPL'
 PLUGIN_LICENSE_URL = 'http://www.wtfpl.net/'
@@ -282,7 +282,7 @@ class Wikidata:
             self.requests.clear()
             log.info('WIKIDATA: Finished (B)')
 
-    def process_track(self, album, metadata, trackXmlNode, releaseXmlNode):
+    def process_track(self, album, metadata, track, release):
         self.update_settings()
         self.ws = album.tagger.webservice
         self.log = album.log


### PR DESCRIPTION
The `track_metadata_processor` gets actually called with parameters `(tagger, metadata, track, release)`, but many plugins which do not use the last two parameters switched them around. This is confusing to new developers.

This updates all plugins to list the correct parameter order. There is no functional change or fix in any of the plugins, only getting the names right. All cases where this was switched where plugins that did not use the `track` and `release` parameters.