### PR TITLE
wikidata, albumartist_website: fixed access to Metadata

### DIFF
--- a/plugins/albumartist_website/albumartist_website.py
+++ b/plugins/albumartist_website/albumartist_website.py
@@ -4,8 +4,8 @@ PLUGIN_NAME = 'Album Artist Website'
 PLUGIN_AUTHOR = 'Sophist, Sambhav Kothari'
 PLUGIN_DESCRIPTION = '''Add's the album artist(s) Official Homepage(s)
 (if they are defined in the MusicBrainz database).'''
-PLUGIN_VERSION = '1.0.1'
-PLUGIN_API_VERSIONS = ["2.0"]
+PLUGIN_VERSION = '1.0.2'
+PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
@@ -65,7 +65,7 @@ class AlbumArtistWebsite:
         self.website_queue = self.ArtistWebsiteQueue()
 
     def add_artist_website(self, album, track_metadata, track_node, release_node):
-        albumArtistIds = dict.get(track_metadata,'musicbrainz_albumartistid', [])
+        albumArtistIds = track_metadata.getall('musicbrainz_albumartistid')
         for artistId in albumArtistIds:
             if artistId in self.website_cache:
                 if self.website_cache[artistId]:

--- a/plugins/wikidata/__init__.py
+++ b/plugins/wikidata/__init__.py
@@ -8,8 +8,8 @@
 PLUGIN_NAME = 'Wikidata Genre'
 PLUGIN_AUTHOR = 'Daniel Sobey, Sambhav Kothari'
 PLUGIN_DESCRIPTION = 'query wikidata to get genre tags'
-PLUGIN_VERSION = '1.4.1'
-PLUGIN_API_VERSIONS = ["2.0"]
+PLUGIN_VERSION = '1.4.2'
+PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2"]
 PLUGIN_LICENSE = 'WTFPL'
 PLUGIN_LICENSE_URL = 'http://www.wtfpl.net/'
 
@@ -90,11 +90,11 @@ class Wikidata:
     def process_release(self, album, metadata, release):
         self.ws = album.tagger.webservice
         self.log = album.log
-        item_id = dict.get(metadata, 'musicbrainz_releasegroupid')[0]
+        item_id = metadata.getall('musicbrainz_releasegroupid')[0]
 
         log.info('WIKIDATA: Processing release group %s ' % item_id)
         self.process_request(metadata, album, item_id, item_type='release-group')
-        for artist in dict.get(metadata, 'musicbrainz_albumartistid'):
+        for artist in metadata.getall('musicbrainz_albumartistid'):
             item_id = artist
             log.info('WIKIDATA: Processing release artist %s' % item_id)
             self.process_request(metadata, album, item_id, item_type='artist')


### PR DESCRIPTION
The plugins where using dict.get on the Metadata instance, which is no longer a dict. This was also never intented use of the Metadata API.