### PR TITLE
Improve performance for Remove perfect albums

### DIFF
--- a/plugins/remove_perfect_albums/remove_perfect_albums.py
+++ b/plugins/remove_perfect_albums/remove_perfect_albums.py
@@ -1,10 +1,12 @@
 PLUGIN_NAME = 'Remove Perfect Albums'
 PLUGIN_AUTHOR = 'ichneumon, hrglgrmpf'
 PLUGIN_DESCRIPTION = '''Remove all perfectly matched albums from the selection.'''
-PLUGIN_VERSION = '0.2'
-PLUGIN_API_VERSIONS = ['0.15', '2.0']
+PLUGIN_VERSION = '0.3'
+PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2', '2.3']
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
+
+from PyQt5.QtCore import QCoreApplication
 
 from picard.album import Album
 from picard.ui.itemviews import BaseAction, register_album_action
@@ -17,5 +19,6 @@ class RemovePerfectAlbums(BaseAction):
             if (isinstance(album, Album) and album.loaded and album.is_complete()
               	and album.get_num_unsaved_files() == 0):
                 self.tagger.remove_album(album)
+            QCoreApplication.processEvents()
 
 register_album_action(RemovePerfectAlbums())

--- a/plugins/remove_perfect_albums/remove_perfect_albums.py
+++ b/plugins/remove_perfect_albums/remove_perfect_albums.py
@@ -11,14 +11,16 @@ from PyQt5.QtCore import QCoreApplication
 from picard.album import Album
 from picard.ui.itemviews import BaseAction, register_album_action
 
+
 class RemovePerfectAlbums(BaseAction):
     NAME = 'Remove perfect albums'
 
     def callback(self, objs):
         for album in objs:
-            if (isinstance(album, Album) and album.loaded and album.is_complete()
-              	and album.get_num_unsaved_files() == 0):
+            if (isinstance(album, Album) and album.loaded
+               and album.is_complete() and album.get_num_unsaved_files() == 0):
                 self.tagger.remove_album(album)
             QCoreApplication.processEvents()
+
 
 register_album_action(RemovePerfectAlbums())

--- a/plugins/remove_perfect_albums/remove_perfect_albums.py
+++ b/plugins/remove_perfect_albums/remove_perfect_albums.py
@@ -14,9 +14,8 @@ class RemovePerfectAlbums(BaseAction):
 
     def callback(self, objs):
         for album in objs:
-            if (isinstance(album, Album) and album.is_complete() and album.get_num_unmatched_files() == 0
-              	and album.get_num_matched_tracks() == len(list(album.iterfiles()))
-              	and album.get_num_unsaved_files() == 0 and album.loaded == True):
+            if (isinstance(album, Album) and album.loaded and album.is_complete()
+              	and album.get_num_unsaved_files() == 0):
                 self.tagger.remove_album(album)
 
 register_album_action(RemovePerfectAlbums())


### PR DESCRIPTION
Optimize the performance and responsiveness of remove_perfect_albums by optimizing the perfect check and calling `QCoreApplication.processEvents()` in between.

The if condition was optimized with:
- album.get_num_unmatched_files() == 0: not needed, already checked by album.is_complete()
- album.get_num_matched_tracks() == len(list(album.iterfiles())): not needed, each track.is_complete() already checks whether linked tracks is exactly 1
- move album.loaded before the expensive calls

Due to the import of PyQt5 this breaks compatibility with Picard 1.4. Also the above assumptions for optimizing the condition probably do not apply to Picard 1.x.