### PR TITLE
standardise_feat: Consider trailing join phrase

### DIFF
--- a/plugins/standardise_feat/standardise_feat.py
+++ b/plugins/standardise_feat/standardise_feat.py
@@ -1,8 +1,8 @@
 PLUGIN_NAME = 'Standardise Feat.'
 PLUGIN_AUTHOR = 'Sambhav Kothari'
 PLUGIN_DESCRIPTION = 'Standardises "featuring" join phrases for artists to "feat."'
-PLUGIN_VERSION = "0.2"
-PLUGIN_API_VERSIONS = ["1.4", "2.0"]
+PLUGIN_VERSION = "0.3"
+PLUGIN_API_VERSIONS = ["1.4", "2.0", "2.1", "2.2", "2.3"]
 PLUGIN_LICENSE = "GPL-3.0"
 PLUGIN_LICENSE_URL = "http://www.gnu.org/licenses/gpl-3.0.txt"
 
@@ -15,7 +15,17 @@ _feat_re = re.compile(r" f(ea)?t(\.|uring)? ", re.IGNORECASE)
 
 
 def standardise_feat(artists_str, artists_list):
-    match_exp = r"(\s*.*\s*)".join((map(re.escape, artists_list)))
+    """
+    >>> standardise_feat("The A", ["The A"])
+    'The A'
+    >>> standardise_feat("The A ft. B", ["The A", "B"])
+    'The A feat. B'
+    >>> standardise_feat("The A & B featuring C", ["The A", "B", "C"])
+    'The A & B feat. C'
+    >>> standardise_feat("The A featuring B (and C)", ["The A", "B", "C"])
+    'The A feat. B (and C)'
+    """
+    match_exp = r"(\s*.*\s*)".join((map(re.escape, artists_list))) + r"(\s*.*$)"
     try:
         join_phrases = re.match(match_exp, artists_str).groups()
     except AttributeError:

--- a/test.py
+++ b/test.py
@@ -93,6 +93,8 @@ def load_tests(loader, tests, ignore):
     tests.addTests(doctest.DocTestSuite(addrelease))
     from plugins import decade
     tests.addTests(doctest.DocTestSuite(decade))
+    from plugins.standardise_feat import standardise_feat
+    tests.addTests(doctest.DocTestSuite(standardise_feat))
     return tests
 
 


### PR DESCRIPTION
The standardise_feat plugin removes trailing join phrases.

Added fix + tests

Fixes PICARD-1742