### PR TITLE
Make test.py a real unittest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install picard
     - name: Test plugins
-      run: python test.py
+      run: python -m unittest discover -v

--- a/test/test_doctest.py
+++ b/test/test_doctest.py
@@ -1,0 +1,11 @@
+import doctest
+
+
+def load_tests(loader, tests, ignore):
+    from plugins.addrelease import addrelease
+    tests.addTests(doctest.DocTestSuite(addrelease))
+    from plugins import decade
+    tests.addTests(doctest.DocTestSuite(decade))
+    from plugins.standardise_feat import standardise_feat
+    tests.addTests(doctest.DocTestSuite(standardise_feat))
+    return tests


### PR DESCRIPTION
It's not too much work and it's always nicer to use a standard test setup.

Also, this creates a `test` folder that other test can be put into in the
future.

Also, this creates `test/test_doctest.py` that keeps the list of doctests to run.