### PR TITLE
keep: Make it possible to keep tags with descriptions without enumerating all possible ones

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install picard
     - name: Test plugins
-      run: python test.py
+      run: python -m unittest discover -v

--- a/plugins/keep/keep.py
+++ b/plugins/keep/keep.py
@@ -18,17 +18,11 @@ PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 from picard.script import register_script_function
 
 
-def transltag(tag):
-    if tag.startswith("~"):
-        return "_" + tag[1:]
-    return tag
-
-
 @register_script_function
 def keep(parser, *keeptags):
     tags = list(parser.context.keys())
     for tag in tags:
-        if (transltag(tag) in keeptags or
+        if (tag in keeptags or
             tag.startswith("musicbrainz_") or
             tag.startswith("~")):
             continue

--- a/plugins/keep/keep.py
+++ b/plugins/keep/keep.py
@@ -3,9 +3,13 @@ PLUGIN_AUTHOR = "Wieland Hoffmann"
 PLUGIN_DESCRIPTION = """
 Adds a $keep() function to delete all tags except the ones that you want.
 Tags beginning with `musicbrainz_` are kept automatically, as are tags
-beginning with `_`."""
+beginning with `_`.
 
-PLUGIN_VERSION = "1.1"
+To keep all tags that can have a description (like `comment`, lyrics` and
+`performer`), add `<tagname without description>` (not including `:`) to the
+list of tags to keep."""
+
+PLUGIN_VERSION = "1.2"
 PLUGIN_API_VERSIONS = ["0.15.0", "0.15.1", "0.16.0", "1.0.0", "1.1.0", "1.2.0",
                        "1.3.0", "2.0"]
 PLUGIN_LICENSE = "GPL-2.0-or-later"
@@ -24,8 +28,13 @@ def transltag(tag):
 def keep(parser, *keeptags):
     tags = list(parser.context.keys())
     for tag in tags:
-        if (transltag(tag) not in keeptags and
-            not tag.startswith("musicbrainz_") and
-                not tag.startswith("~")):
-            parser.context.pop(tag, None)
+        if (transltag(tag) in keeptags or
+            tag.startswith("musicbrainz_") or
+            tag.startswith("~")):
+            continue
+        if ":" in tag:
+            tag_without_description = tag.split(":")[0]
+            if tag_without_description in keeptags:
+                continue
+        parser.context.pop(tag, None)
     return ""

--- a/test/test_doctest.py
+++ b/test/test_doctest.py
@@ -1,0 +1,11 @@
+import doctest
+
+
+def load_tests(loader, tests, ignore):
+    from plugins.addrelease import addrelease
+    tests.addTests(doctest.DocTestSuite(addrelease))
+    from plugins import decade
+    tests.addTests(doctest.DocTestSuite(decade))
+    from plugins.standardise_feat import standardise_feat
+    tests.addTests(doctest.DocTestSuite(standardise_feat))
+    return tests

--- a/test/test_keep.py
+++ b/test/test_keep.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# coding: utf-8
+import unittest
+
+from picard.metadata import Metadata
+from picard.script import ScriptParser
+from plugins.keep.keep import keep  # noqa: F401 pylint: disable=unused-import
+
+
+class TestKeep(unittest.TestCase):
+    def setUp(self):
+        self.parser = ScriptParser()
+
+    def test_keep_simple(self):
+        meta = Metadata(
+            {
+                "foo": "foo",
+                "bar": "bar"
+            })
+
+        sc = """$keep(bar)"""
+        self.parser.eval(sc, meta)
+        self.assertEqual(meta["bar"], "bar")
+        self.assertEqual(len(meta.keys()), 1)
+        self.assertNotIn("foo", meta)
+
+    def test_keep_mbid(self):
+        meta = Metadata(
+            {
+                "foo": "foo",
+                "bar": "bar",
+                "musicbrainz_albumid": "albumid",
+            })
+
+        sc = """$keep(bar)"""
+        self.parser.eval(sc, meta)
+        self.assertEqual(meta["musicbrainz_albumid"], "albumid")
+        self.assertEqual(len(meta.keys()), 2)
+
+    def test_keep_nonfiletags(self):
+        meta = Metadata(
+            {
+                "foo": "foo",
+                "bar": "bar",
+                "~baz": "baz",
+            })
+
+        sc = """$keep(bar)"""
+        self.parser.eval(sc, meta)
+        self.assertEqual(meta["~baz"], "baz")
+        self.assertEqual(len(meta.keys()), 2)
+
+    def _description_test(self, tagname):
+        meta = Metadata(
+            {
+                "foo": "foo",
+                "bar": "bar",
+                tagname: tagname
+            })
+
+        tag_without_description = tagname.split(":")[0]
+        sc = """$keep({tag})""".format(tag=tag_without_description)
+        self.parser.eval(sc, meta)
+        self.assertEqual(meta[tagname], tagname)
+        self.assertEqual(len(meta.keys()), 1)
+
+    def test_keep_performer(self):
+        self._description_test("performer:vocal")
+        self._description_test("performer:")
+
+    def test_keep_lyrics(self):
+        self._description_test("lyrics:foo")
+        self._description_test("lyrics:")
+
+    def test_keep_comment(self):
+        self._description_test("comment:foo")
+        self._description_test("comment:")
+
+    def test_keep_with_description(self):
+        meta = Metadata(
+            {
+                "foo": "foo",
+                "bar": "bar",
+                "performer:vocal": "performer:vocal",
+                "performer:guitar": "performer:guitar"
+            })
+
+        sc = """$keep(performer:vocal)"""
+        self.parser.eval(sc, meta)
+        self.assertEqual(meta["performer:vocal"], "performer:vocal")
+        self.assertEqual(len(meta.keys()), 1)


### PR DESCRIPTION
This allows keeping tags with descriptions like performer:, lyrics: and
comment:. We simply check if the part of the tag name before the separator (so
`performer`) should be kept.

This still allows keeping only tags with specific descriptions.

Also includes are a clean-up commit and the commit previously proposed in #254.