### PR TITLE
Indentation problem

### DIFF
--- a/plugins/classical_extras/__init__.py
+++ b/plugins/classical_extras/__init__.py
@@ -6574,7 +6574,7 @@ class PartLevels():
                     colon_ind = work.rfind(':')
                     work = work[:colon_ind]
                     inter_work = work[colon_ind+1:]
-                movt = title_split[1]
+                    movt = title_split[1]
         write_log(release_id, 'info', "Work %s, Movt %s", work, movt)
         return work, movt, inter_work
 


### PR DESCRIPTION
  Problem with the indentation so calling

      mvt = title_split[1]

  in all case would cause a exit error when the size of the split are only 1 and
  i'm guessing the test colon >1 are to prevent that