### PR TITLE
Add help URLs to some plugin option pages

### DIFF
--- a/plugins/format_performer_tags/__init__.py
+++ b/plugins/format_performer_tags/__init__.py
@@ -27,7 +27,7 @@ each of the tracks.  The format of the resulting tags can be customized
 in the option settings page.
 '''
 
-PLUGIN_VERSION = "0.7"
+PLUGIN_VERSION = "0.8"
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -130,6 +130,7 @@ class FormatPerformerTagsOptionsPage(OptionsPage):
     NAME = "format_performer_tags"
     TITLE = "Format Performer Tags"
     PARENT = "plugins"
+    HELP_URL = "https://github.com/metabrainz/picard-plugins/blob/2.0/plugins/format_performer_tags/docs/README.md"
 
     options = [
         config.IntOption("setting", "format_group_additional", 3),

--- a/plugins/search_engine_lookup/__init__.py
+++ b/plugins/search_engine_lookup/__init__.py
@@ -20,7 +20,7 @@
 PLUGIN_NAME = 'Search Engine Lookup'
 PLUGIN_AUTHOR = 'Bob Swift'
 PLUGIN_DESCRIPTION = '''Adds a right click option on a cluster to look up album information using a search engine in a browser window.'''
-PLUGIN_VERSION = '2.0.0'
+PLUGIN_VERSION = '2.0.1'
 PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2', '2.3']
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
@@ -153,6 +153,7 @@ class SearchEngineLookupOptionsPage(OptionsPage):
     NAME = "search_engine_lookup_options"
     TITLE = "Search Engine Lookup"
     PARENT = "plugins"
+    HELP_URL = "https://github.com/metabrainz/picard-plugins/blob/2.0/plugins/search_engine_lookup/README.md"
 
     options = [
         config.Option("setting", KEY_PROVIDERS, DEFAULT_PROVIDERS.copy()),


### PR DESCRIPTION
Those plugins by @rdswift provide some extended documentation, I think it makes sense to link to it.

Classical extras is another candidate, but since it is mostly developed in @MetaTunes's repository I'd rather have this submitted to upstream and merge this later. 