### PR TITLE
theaudiodb: Add option to use high resolution images

### DIFF
--- a/plugins/theaudiodb/__init__.py
+++ b/plugins/theaudiodb/__init__.py
@@ -20,7 +20,7 @@
 PLUGIN_NAME = 'TheAudioDB cover art'
 PLUGIN_AUTHOR = 'Philipp Wolfer'
 PLUGIN_DESCRIPTION = 'Use cover art from TheAudioDB.'
-PLUGIN_VERSION = "1.1.1"
+PLUGIN_VERSION = "1.2"
 PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4"]
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -38,7 +38,10 @@ from picard.ui.options import (
     register_options_page,
     OptionsPage,
 )
-from picard.config import TextOption
+from picard.config import (
+    BoolOption,
+    TextOption,
+)
 from picard.webservice import ratecontrol
 from .ui_options_theaudiodb import Ui_TheAudioDbOptionsPage
 
@@ -118,7 +121,11 @@ class CoverArtProviderTheAudioDb(CoverArtProvider):
                               reply.url().url())
                     return
                 release = releases[0]
-                albumart_url = release.get("strAlbumThumb")
+                albumart_url = None
+                if config.setting['theaudiodb_use_high_quality']:
+                    albumart_url = release.get("strAlbumThumbHQ")
+                if not albumart_url:
+                    albumart_url = release.get("strAlbumThumb")
                 cdart_url = release.get("strAlbumCDart")
                 use_cdart = config.setting["theaudiodb_use_cdart"]
 
@@ -150,6 +157,7 @@ class TheAudioDbOptionsPage(OptionsPage):
 
     options = [
         TextOption("setting", "theaudiodb_use_cdart", OPTION_CDART_NOALBUMART),
+        BoolOption("setting", "theaudiodb_use_high_quality", False),
     ]
 
     def __init__(self, parent=None):
@@ -164,6 +172,7 @@ class TheAudioDbOptionsPage(OptionsPage):
             self.ui.theaudiodb_cdart_use_never.setChecked(True)
         elif config.setting["theaudiodb_use_cdart"] == OPTION_CDART_NOALBUMART:
             self.ui.theaudiodb_cdart_use_if_no_albumcover.setChecked(True)
+        self.ui.theaudiodb_use_high_quality.setChecked(config.setting['theaudiodb_use_high_quality'])
 
     def save(self):
         if self.ui.theaudiodb_cdart_use_always.isChecked():
@@ -172,6 +181,7 @@ class TheAudioDbOptionsPage(OptionsPage):
             config.setting["theaudiodb_use_cdart"] = OPTION_CDART_NEVER
         elif self.ui.theaudiodb_cdart_use_if_no_albumcover.isChecked():
             config.setting["theaudiodb_use_cdart"] = OPTION_CDART_NOALBUMART
+        config.setting['theaudiodb_use_high_quality'] = self.ui.theaudiodb_use_high_quality.isChecked()
 
 
 register_cover_art_provider(CoverArtProviderTheAudioDb)

--- a/plugins/theaudiodb/options_theaudiodb.ui
+++ b/plugins/theaudiodb/options_theaudiodb.ui
@@ -52,7 +52,7 @@
         <property name="text">
          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;/head&gt;&lt;body&gt;
-&lt;p&gt;This plugin loads cover art from &lt;a href=&quot;https://www.theaudiodb.com&quot;&gt;TheAudioDB&lt;/a&gt;. TheAudioDB is a community Database of audio artwork and data. Their content is only possible thanks to the hard work of volunteer editors. If you like this plugin, please consider &lt;a href=&quot;https://www.theaudiodb.com/forum-new/ucp.php?mode=register&quot;&gt;registering&lt;/a&gt; as an editor or supporting the TheAudioDB &lt;a href=&quot;https://www.patreon.com/thedatadb&quot;&gt;patreon campaign&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p&gt;This plugin loads cover art from &lt;a href=&quot;https://www.theaudiodb.com&quot;&gt;TheAudioDB&lt;/a&gt;. TheAudioDB is a community Database of audio artwork and data. Their content is only possible thanks to the hard work of volunteer editors. If you like this plugin, please consider &lt;a href=&quot;https://www.theaudiodb.com/user_register_now.php&quot;&gt;registering&lt;/a&gt; as an editor or supporting the TheAudioDB &lt;a href=&quot;https://www.patreon.com/thedatadb&quot;&gt;patreon campaign&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="textFormat">
          <enum>Qt::RichText</enum>

--- a/plugins/theaudiodb/options_theaudiodb.ui
+++ b/plugins/theaudiodb/options_theaudiodb.ui
@@ -99,6 +99,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="theaudiodb_use_high_quality">
+     <property name="text">
+      <string>Use high resolution images, if available</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/plugins/theaudiodb/ui_options_theaudiodb.py
+++ b/plugins/theaudiodb/ui_options_theaudiodb.py
@@ -59,7 +59,7 @@ class Ui_TheAudioDbOptionsPage(object):
         self.groupBox.setTitle(_translate("TheAudioDbOptionsPage", "TheAudioDB cover art"))
         self.label.setText(_translate("TheAudioDbOptionsPage", "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
 "<html><head><meta name=\"qrichtext\" content=\"1\" /></head><body>\n"
-"<p>This plugin loads cover art from <a href=\"https://www.theaudiodb.com\">TheAudioDB</a>. TheAudioDB is a community Database of audio artwork and data. Their content is only possible thanks to the hard work of volunteer editors. If you like this plugin, please consider <a href=\"https://www.theaudiodb.com/forum-new/ucp.php?mode=register\">registering</a> as an editor or supporting the TheAudioDB <a href=\"https://www.patreon.com/thedatadb\">patreon campaign</a>.</p></body></html>"))
+"<p>This plugin loads cover art from <a href=\"https://www.theaudiodb.com\">TheAudioDB</a>. TheAudioDB is a community Database of audio artwork and data. Their content is only possible thanks to the hard work of volunteer editors. If you like this plugin, please consider <a href=\"https://www.theaudiodb.com/user_register_now.php\">registering</a> as an editor or supporting the TheAudioDB <a href=\"https://www.patreon.com/thedatadb\">patreon campaign</a>.</p></body></html>"))
         self.verticalGroupBox.setTitle(_translate("TheAudioDbOptionsPage", "Medium images"))
         self.theaudiodb_cdart_use_always.setText(_translate("TheAudioDbOptionsPage", "Always load medium images"))
         self.theaudiodb_cdart_use_if_no_albumcover.setText(_translate("TheAudioDbOptionsPage", "Load only if no front cover is available"))

--- a/plugins/theaudiodb/ui_options_theaudiodb.py
+++ b/plugins/theaudiodb/ui_options_theaudiodb.py
@@ -45,6 +45,9 @@ class Ui_TheAudioDbOptionsPage(object):
         self.theaudiodb_cdart_use_never.setObjectName("theaudiodb_cdart_use_never")
         self.verticalLayout.addWidget(self.theaudiodb_cdart_use_never)
         self.vboxlayout.addWidget(self.verticalGroupBox)
+        self.theaudiodb_use_high_quality = QtWidgets.QCheckBox(TheAudioDbOptionsPage)
+        self.theaudiodb_use_high_quality.setObjectName("theaudiodb_use_high_quality")
+        self.vboxlayout.addWidget(self.theaudiodb_use_high_quality)
         spacerItem = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
         self.vboxlayout.addItem(spacerItem)
 
@@ -61,3 +64,4 @@ class Ui_TheAudioDbOptionsPage(object):
         self.theaudiodb_cdart_use_always.setText(_translate("TheAudioDbOptionsPage", "Always load medium images"))
         self.theaudiodb_cdart_use_if_no_albumcover.setText(_translate("TheAudioDbOptionsPage", "Load only if no front cover is available"))
         self.theaudiodb_cdart_use_never.setText(_translate("TheAudioDbOptionsPage", "Never load medium images"))
+        self.theaudiodb_use_high_quality.setText(_translate("TheAudioDbOptionsPage", "Use high resolution images, if available"))


### PR DESCRIPTION
Ads an option to use high resolution images for cover art from TheAudioDB.

One example with such cover art available is:

https://www.theaudiodb.com/album/2349438
https://musicbrainz.org/release-group/2587b239-ca88-47ec-907c-33d0b22ff915
