### PR TITLE
Sort homepages for consistency

### DIFF
--- a/plugins/albumartist_website/albumartist_website.py
+++ b/plugins/albumartist_website/albumartist_website.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = 'Album Artist Website'
 PLUGIN_AUTHOR = 'Sophist, Sambhav Kothari'
 PLUGIN_DESCRIPTION = '''Add's the album artist(s) Official Homepage(s)
 (if they are defined in the MusicBrainz database).'''
-PLUGIN_VERSION = '1.0.2'
+PLUGIN_VERSION = '1.0.3'
 PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -93,7 +93,7 @@ class AlbumArtistWebsite:
             for track, album in tuples:
                 self.album_remove_request(album)
             return
-        urls = self.artist_process_metadata(artistId, response)
+        urls = sorted(self.artist_process_metadata(artistId, response))
         self.website_cache[artistId] = urls
         tuples = self.website_queue.remove(artistId)
         log.debug("%s: %r: Artist Official Homepages = %r", PLUGIN_NAME,


### PR DESCRIPTION
Some artists e.g. Andrew Lloyd Webber have multiple Artist Homepages, and in this event the order of these can be random, making metadata change when source MB data is the same.

This fix sorts the results in order to ensure consistency.