### PR TITLE
[acousticbrainz_tonal-rhythm] Increase rate delay

### DIFF
--- a/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
+++ b/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
@@ -27,7 +27,7 @@ from the AcousticBrainz database.<br/><br/>
 '''
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = '1.1.3'
+PLUGIN_VERSION = '1.1.4'
 PLUGIN_API_VERSIONS = ["2.0"]  # Requires support for TKEY which is in 1.4
 
 from json import JSONDecodeError
@@ -41,7 +41,7 @@ from picard.util import load_json
 ACOUSTICBRAINZ_HOST = "acousticbrainz.org"
 ACOUSTICBRAINZ_PORT = 80
 
-ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 50)
+ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 100)
 
 
 class AcousticBrainz_Key:


### PR DESCRIPTION
Avoid getting rate limit errors with AcousticBrainz:
```
E: 23:37:19,087 webservice\__init__._handle_reply:445: Network request error for http://acousticbrainz.org:80/api/v1/high-level?recording_ids=f2ada1c9-fa39-4d15-aa11-9bd798a885a9&map_classes=true: Error transferring http://acousticbrainz.org:80/api/v1/high-level?recording_ids=f2ada1c9-fa39-4d15-aa11-9bd798a885a9&map_classes=true - server replied: TOO MANY REQUESTS (QT code 299, HTTP code 429)
E: 23:37:19,134 webservice\__init__._handle_reply:445: Network request error for http://acousticbrainz.org:80/f2ada1c9-fa39-4d15-aa11-9bd798a885a9/low-level: Error transferring http://acousticbrainz.org:80/f2ada1c9-fa39-4d15-aa11-9bd798a885a9/low-level - server replied: TOO MANY REQUESTS (QT code 299, HTTP code 429)
```
by increasing the hardcoded delay time from 50ms to 100ms.

See #282 for a better suggested approach following the acousticbrainz API rate limiting model.