### PR TITLE
Added script to build .ui files

### DIFF
--- a/build_ui.py
+++ b/build_ui.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+
+from PyQt5 import uic
+
+
+plugin_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'plugins')
+
+
+def compile_ui(uifile, pyfile):
+    print("compiling %s -> %s" % (uifile, pyfile))
+    with open(pyfile, "w") as out:
+        uic.compileUi(uifile, out)
+
+
+if __name__ == '__main__':
+    for uifile in glob.glob(os.path.join(plugin_dir, '*/*.ui')):
+        pyfile = os.path.splitext(os.path.basename(uifile))[0] + '.py'
+        pyfile = os.path.join(os.path.dirname(uifile), pyfile)
+        compile_ui(uifile, pyfile)


### PR DESCRIPTION
Add a script `build_ui.py` that uses uic to compile all .ui files into Python code.

This helps plugin developers dealing with .ui files and avoids the need of manually running uic.