### PR TITLE
Haikuattrs: Support Media:Length and Audio:Bitrate attributes

### DIFF
--- a/plugins/haikuattrs/haikuattrs.py
+++ b/plugins/haikuattrs/haikuattrs.py
@@ -151,7 +151,8 @@ if be:
                     if tag == 'date':
                         value = value[:4]
                     elif tag == '~length':
-                        value = file.orig_metadata.length
+                        # Haiku expects the Media:Length attribute in nanoseconds
+                        value = file.orig_metadata.length * 1000
                     elif tag == '~rating':
                         try:
                             value = int(value) * 2


### PR DESCRIPTION
To fill these attributes:

![image](https://user-images.githubusercontent.com/29852/121021536-c85afb80-c7a1-11eb-8b1c-b44629882cd0.png)

With this all attributes supported for audio files by Haiku should also be supported by the plugin.