### PR TITLE
AcousticBrainz batch requests

### DIFF
--- a/plugins/acousticbrainz/__init__.py
+++ b/plugins/acousticbrainz/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Acousticbrainz plugin for Picard
+# AcousticBrainz plugin for Picard
 # Copyright (C) 2021 Wargreen
 #
 # This program is free software; you can redistribute it and/or modify
@@ -66,7 +66,7 @@ from picard.webservice import ratecontrol
 from picard.util import load_json
 from picard.ui.options import register_options_page, OptionsPage
 from picard.metadata import register_track_metadata_processor
-from picard.plugins.acousticbrainz.ui_options_acousticbrainz_tags import Ui_AcousticbrainzOptionsPage
+from picard.plugins.acousticbrainz.ui_options_acousticbrainz_tags import Ui_AcousticBrainzOptionsPage
 
 ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 250)
 
@@ -318,7 +318,7 @@ class Track:
 # =============================================================================
 # (provides track processing callback)
 
-class AcousticbrainzPlugin:
+class AcousticBrainzPlugin:
 
     def __init__(self):
         self.tracks = {}
@@ -334,7 +334,7 @@ class AcousticbrainzPlugin:
 # =============================================================================
 # (define plugin options and link with user interface)
 
-class AcousticbrainzOptionsPage(OptionsPage):
+class AcousticBrainzOptionsPage(OptionsPage):
     NAME = "AcousticBrainz"
     TITLE = "AcousticBrainz tags"
     PARENT = "plugins"
@@ -348,8 +348,8 @@ class AcousticbrainzOptionsPage(OptionsPage):
     ]
 
     def __init__(self, parent=None):
-        super(AcousticbrainzOptionsPage, self).__init__(parent)
-        self.ui = Ui_AcousticbrainzOptionsPage()
+        super(AcousticBrainzOptionsPage, self).__init__(parent)
+        self.ui = Ui_AcousticBrainzOptionsPage()
         self.ui.setupUi(self)
 
     def load(self):
@@ -369,6 +369,6 @@ class AcousticbrainzOptionsPage(OptionsPage):
         setting["acousticbrainz_add_sublowlevel"] = self.ui.add_sublowlevel.isChecked()
 
 
-plugin = AcousticbrainzPlugin()
+plugin = AcousticBrainzPlugin()
 register_track_metadata_processor(plugin.process_track)
-register_options_page(AcousticbrainzOptionsPage)
+register_options_page(AcousticBrainzOptionsPage)

--- a/plugins/acousticbrainz/__init__.py
+++ b/plugins/acousticbrainz/__init__.py
@@ -310,10 +310,6 @@ class AcousticBrainzRequest:
             callback=partial(self._batch, action, recording_ids, callback, result))
 
     def _do_request(self, action, recording_ids, callback):
-        queryargs = {
-            'recording_ids': ';'.join(recording_ids),
-            'map_classes': 'true'
-        }
         self.album.tagger.webservice.get(
             ACOUSTICBRAINZ_HOST,
             ACOUSTICBRAINZ_PORT,
@@ -321,8 +317,16 @@ class AcousticBrainzRequest:
             callback,
             priority=True,
             parse_response_type='json',
-            queryargs=queryargs
+            queryargs=self._get_query_args(action, recording_ids)
         )
+
+    def _get_query_args(self, action, recording_ids):
+        queryargs = {
+            'recording_ids': ';'.join(recording_ids),
+        }
+        if action == 'high-level':
+            queryargs['map_classes'] = 'true'
+        return queryargs
 
     def _merge_results(self, full, new):
         mapping = new.get('mbid_mapping', {})

--- a/plugins/acousticbrainz/ui_options_acousticbrainz_tags.py
+++ b/plugins/acousticbrainz/ui_options_acousticbrainz_tags.py
@@ -11,15 +11,15 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 
-class Ui_AcousticbrainzOptionsPage(object):
-    def setupUi(self, AcousticbrainzOptionsPage):
-        AcousticbrainzOptionsPage.setObjectName("AcousticbrainzOptionsPage")
-        AcousticbrainzOptionsPage.setEnabled(True)
-        AcousticbrainzOptionsPage.resize(527, 443)
-        AcousticbrainzOptionsPage.setWindowTitle("")
-        self.verticalLayout = QtWidgets.QVBoxLayout(AcousticbrainzOptionsPage)
+class Ui_AcousticBrainzOptionsPage(object):
+    def setupUi(self, AcousticBrainzOptionsPage):
+        AcousticBrainzOptionsPage.setObjectName("AcousticBrainzOptionsPage")
+        AcousticBrainzOptionsPage.setEnabled(True)
+        AcousticBrainzOptionsPage.resize(527, 443)
+        AcousticBrainzOptionsPage.setWindowTitle("")
+        self.verticalLayout = QtWidgets.QVBoxLayout(AcousticBrainzOptionsPage)
         self.verticalLayout.setObjectName("verticalLayout")
-        self.acousticbrainzTags_groupBox = QtWidgets.QGroupBox(AcousticbrainzOptionsPage)
+        self.acousticbrainzTags_groupBox = QtWidgets.QGroupBox(AcousticBrainzOptionsPage)
         self.acousticbrainzTags_groupBox.setObjectName("acousticbrainzTags_groupBox")
         self.verticalLayout_2 = QtWidgets.QVBoxLayout(self.acousticbrainzTags_groupBox)
         self.verticalLayout_2.setObjectName("verticalLayout_2")
@@ -48,15 +48,15 @@ class Ui_AcousticbrainzOptionsPage(object):
         self.verticalLayout_2.addItem(spacerItem1)
         self.verticalLayout.addWidget(self.acousticbrainzTags_groupBox)
 
-        self.retranslateUi(AcousticbrainzOptionsPage)
-        QtCore.QMetaObject.connectSlotsByName(AcousticbrainzOptionsPage)
+        self.retranslateUi(AcousticBrainzOptionsPage)
+        QtCore.QMetaObject.connectSlotsByName(AcousticBrainzOptionsPage)
 
-    def retranslateUi(self, AcousticbrainzOptionsPage):
+    def retranslateUi(self, AcousticBrainzOptionsPage):
         _translate = QtCore.QCoreApplication.translate
-        self.acousticbrainzTags_groupBox.setTitle(_translate("AcousticbrainzOptionsPage", "AcousticBrainz Tags"))
-        self.add_simplemood.setText(_translate("AcousticbrainzOptionsPage", "Add simple Mood tags"))
-        self.add_simplegenre.setText(_translate("AcousticbrainzOptionsPage", "Add simple Genre tags"))
-        self.add_keybpm.setText(_translate("AcousticbrainzOptionsPage", "Add simple BPM and Key tags"))
-        self.add_fullhighlevel.setText(_translate("AcousticbrainzOptionsPage", "Add all highlevel AcousticBrainz tags"))
-        self.add_sublowlevel.setText(_translate("AcousticbrainzOptionsPage", "Add a subset of the lowlevel AcousticBrainz tags"))
-        self.sublowlevel_descr.setText(_translate("AcousticbrainzOptionsPage", "<html><head/><body><p>The low level subset include:</p><ul style=\"margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;\"><li style=\" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">rhythm:bpm</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:chords_change_rate</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:chords_key</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:chords_scale</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:key_key</li><li style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:key_scale</li></ul></body></html>"))
+        self.acousticbrainzTags_groupBox.setTitle(_translate("AcousticBrainzOptionsPage", "AcousticBrainz Tags"))
+        self.add_simplemood.setText(_translate("AcousticBrainzOptionsPage", "Add simple Mood tags"))
+        self.add_simplegenre.setText(_translate("AcousticBrainzOptionsPage", "Add simple Genre tags"))
+        self.add_keybpm.setText(_translate("AcousticBrainzOptionsPage", "Add simple BPM and Key tags"))
+        self.add_fullhighlevel.setText(_translate("AcousticBrainzOptionsPage", "Add all highlevel AcousticBrainz tags"))
+        self.add_sublowlevel.setText(_translate("AcousticBrainzOptionsPage", "Add a subset of the lowlevel AcousticBrainz tags"))
+        self.sublowlevel_descr.setText(_translate("AcousticBrainzOptionsPage", "<html><head/><body><p>The low level subset include:</p><ul style=\"margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;\"><li style=\" margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">rhythm:bpm</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:chords_change_rate</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:chords_key</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:chords_scale</li><li style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:key_key</li><li style=\" margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">tonal:key_scale</li></ul></body></html>"))

--- a/plugins/acousticbrainz/ui_options_acousticbrainz_tags.ui
+++ b/plugins/acousticbrainz/ui_options_acousticbrainz_tags.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>AcousticbrainzOptionsPage</class>
- <widget class="QWidget" name="AcousticbrainzOptionsPage">
+ <class>AcousticBrainzOptionsPage</class>
+ <widget class="QWidget" name="AcousticBrainzOptionsPage">
   <property name="enabled">
    <bool>true</bool>
   </property>


### PR DESCRIPTION
Refactor the (new) AcousticBrainz plugin to batch requests for 25 recordings.

Batching is done per album, so at minimum there will be one request per album and details level (low, high). For the majority of cases that means 1 request per album per level. Special handling for non-album tracks, as those do not trigger the album metadata hook.

Discussion: It would of course also be possible to batch across albums. But that would make the handling much more complicated. I think for now this provides a good compromise.

Fixes https://github.com/metabrainz/picard-plugins/issues/233
