### PR TITLE
Add multi-value variables for artist types and join phrases

### DIFF
--- a/plugins/additional_artists_variables/additional_artists_variables.py
+++ b/plugins/additional_artists_variables/additional_artists_variables.py
@@ -30,7 +30,7 @@ this plugin.
 <br /><br />
 Please see the <a href="https://github.com/rdswift/picard-plugins/blob/2.0_RDS_Plugins/plugins/additional_artists_variables/docs/README.md">user guide</a> on GitHub for more information.
 '''
-PLUGIN_VERSION = '0.8'
+PLUGIN_VERSION = '0.8.1'
 PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2', '2.7']
 PLUGIN_LICENSE = 'GPL-2.0-or-later'
 PLUGIN_LICENSE_URL = 'https://www.gnu.org/licenses/gpl-2.0.html'
@@ -128,8 +128,8 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
             std_artist += temp_std_name + temp_phrase
             cred_artist += temp_cred_name + temp_phrase
             sort_artist += temp_sort_name + temp_phrase
-            artist_types.append(temp_type)
-            artist_join_phrases.append(temp_phrase)
+            artist_types.append(temp_type if temp_type else 'unknown',)
+            artist_join_phrases.append(temp_phrase if temp_phrase else '[blank]',)
             if temp_legal_name:
                 legal_artist += temp_legal_name + temp_phrase
                 legal_artist_list.append(temp_legal_name,)

--- a/plugins/additional_artists_variables/additional_artists_variables.py
+++ b/plugins/additional_artists_variables/additional_artists_variables.py
@@ -129,7 +129,7 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
             cred_artist += temp_cred_name + temp_phrase
             sort_artist += temp_sort_name + temp_phrase
             artist_types.append(temp_type if temp_type else 'unknown',)
-            artist_join_phrases.append(temp_phrase if temp_phrase else '[blank]',)
+            artist_join_phrases.append(temp_phrase if temp_phrase else '\u200B',)
             if temp_legal_name:
                 legal_artist += temp_legal_name + temp_phrase
                 legal_artist_list.append(temp_legal_name,)

--- a/plugins/additional_artists_variables/additional_artists_variables.py
+++ b/plugins/additional_artists_variables/additional_artists_variables.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 Bob Swift (rdswift)
+# Copyright (C) 2018, 2021 Bob Swift (rdswift)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -30,8 +30,8 @@ this plugin.
 <br /><br />
 Please see the <a href="https://github.com/rdswift/picard-plugins/blob/2.0_RDS_Plugins/plugins/additional_artists_variables/docs/README.md">user guide</a> on GitHub for more information.
 '''
-PLUGIN_VERSION = '0.7.1'
-PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2']
+PLUGIN_VERSION = '0.8'
+PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2', '2.7']
 PLUGIN_LICENSE = 'GPL-2.0-or-later'
 PLUGIN_LICENSE_URL = 'https://www.gnu.org/licenses/gpl-2.0.html'
 
@@ -66,6 +66,8 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
         legal_artist_list = []
         artist_count = 0
         artist_ids = []
+        artist_types = []
+        artist_join_phrases = []
         for artist_credit in source_metadata['artist-credit']:
             # Initialize temporary variables for each loop.
             temp_std_name = ''
@@ -75,6 +77,7 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
             temp_legal_sort_name = ''
             temp_phrase = ''
             temp_id = ''
+            temp_type = ''
             # Check if there is a 'joinphrase' specified.
             if 'joinphrase' in artist_credit:
                 temp_phrase = artist_credit['joinphrase']
@@ -99,6 +102,10 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
                     temp_sort_name = artist_credit['artist']['sort-name']
                 else:
                     metadata_error(album_id, 'artist-credit.artist.sort-name', source_type)
+                if 'type' in artist_credit['artist']:
+                    temp_type = artist_credit['artist']['type']
+                else:
+                    metadata_error(album_id, 'artist-credit.artist.type', source_type)
                 if 'aliases' in artist_credit['artist']:
                     for item in artist_credit['artist']['aliases']:
                         if 'type-id' in item and item['type-id'] =='d4dcd0c0-b341-3612-a332-c0ce797b25cf':
@@ -121,6 +128,8 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
             std_artist += temp_std_name + temp_phrase
             cred_artist += temp_cred_name + temp_phrase
             sort_artist += temp_sort_name + temp_phrase
+            artist_types.append(temp_type)
+            artist_join_phrases.append(temp_phrase)
             if temp_legal_name:
                 legal_artist += temp_legal_name + temp_phrase
                 legal_artist_list.append(temp_legal_name,)
@@ -200,6 +209,10 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
         destination_metadata['~artists_{0}_all_legal_multi'.format(source_type,)] = legal_artist_list
     if sort_pri_artist:
         destination_metadata['~artists_{0}_all_sort_primary'.format(source_type,)] = sort_pri_artist
+    if artist_types:
+        destination_metadata['~artists_{0}_all_types'.format(source_type,)] = artist_types
+    if artist_join_phrases:
+        destination_metadata['~artists_{0}_all_join_phrases'.format(source_type,)] = artist_join_phrases
     if artist_count:
         destination_metadata['~artists_{0}_all_count'.format(source_type,)] = artist_count
 


### PR DESCRIPTION
Note:  This PR replaces #320 

As discussed in the [Community Forum](https://community.metabrainz.org/t/artist-variables-plugin/409544/13) this update provides the following new multi-value variables:

* **_artists_album_all_types** - All album artist types, as a multi-value
* **_artists_album_all_join_phrases** - All album artist join phrases, as a multi-value
* **_artists_track_all_types** - All track artist types, as a multi-value
* **_artists_track_all_join_phrases** - All track artist join phrases, as a multi-value

I had to add a default value of **'[blank]'** for join phrases consisting of an empty string because Picard removes empty strings from a multi-value in [line 436 of picard.metadata.py](https://github.com/metabrainz/picard/blob/6ac0501f55f2df6dd5e5f032dbedfb226467665f/picard/metadata.py#L432-L441)::

    def set(self, name, values):
        name = self.normalize_tag(name)
        if isinstance(values, str) or not isinstance(values, Iterable):
            values = [values]
        values = [str(value) for value in values if value or value == 0]     # This is the line #
        if values:
            self._store[name] = values
            self.deleted_tags.discard(name)
        elif name in self._store:
            del self[name]

This seems like a bit of a hack, but can work in scripts if the user does an appropriate `$replace()` for the default value.

@zas / @phw do you know off hand if changing this to:

    def set(self, name, values):
        name = self.normalize_tag(name)
        if isinstance(values, str) or not isinstance(values, Iterable):
            values = [values]
        values = [str(value) for value in values if value or value == 0 or value == '']
        if values and (len(values) > 1 or values[0]):
            self._store[name] = values
            self.deleted_tags.discard(name)
        elif name in self._store:
            del self[name]

would break things, other than the two tests that I know fail (`test_cmd_setmulti_custom_splitter_string` and `test_cmd_setmulti_will_remove_empty_items`)?  Is there another (better) way to preserve empty string elements in a multi-value variable, or is that something that we just do **not** want to do?
