### PR TITLE
Update AcousticBrainz Tags with configurable tag names

### DIFF
--- a/plugins/acousticbrainz/__init__.py
+++ b/plugins/acousticbrainz/__init__.py
@@ -22,10 +22,10 @@
 # =============================================================================
 
 PLUGIN_NAME = 'AcousticBrainz Tags'
-PLUGIN_AUTHOR = ('<a href="mailto:wargreen@lebib.org">Wargreen</a>, '
-                 '<a href="mailto:pistache@lebib.org">Hugo Geoffroy "pistache"</a>, '
-                 '<a href="mailto:ph.wolfer@gmail.com">Philipp Wolfer</a>, '
-                 '<a href="mailto:regorxxx@protonmail.com">Regorxxx</a>')
+PLUGIN_AUTHOR = ('Wargreen <wargreen@lebib.org>, '
+                 'Hugo Geoffroy "pistache" <pistache@lebib.org>, '
+                 'Philipp Wolfer <ph.wolfer@gmail.com>, '
+                 'Regorxxx <regorxxx@protonmail.com>')
 PLUGIN_DESCRIPTION = '''
 Tag files with tags from the AcousticBrainz database, all highlevel classifiers
 and tonal/rhythm data.

--- a/plugins/acousticbrainz/__init__.py
+++ b/plugins/acousticbrainz/__init__.py
@@ -22,9 +22,10 @@
 # =============================================================================
 
 PLUGIN_NAME = 'AcousticBrainz Tags'
-PLUGIN_AUTHOR = ('Wargreen <wargreen@lebib.org>, '
-                 'Hugo Geoffroy "pistache" <pistache@lebib.org>, '
-                 'Philipp Wolfer <ph.wolfer@gmail.com>')
+PLUGIN_AUTHOR = ('<a href="mailto:wargreen@lebib.org">Wargreen</a>, '
+                 '<a href="mailto:pistache@lebib.org">Hugo Geoffroy "pistache"</a>, '
+                 '<a href="mailto:ph.wolfer@gmail.com">Philipp Wolfer</a>, '
+                 '<a href="mailto:regorxxx@protonmail.com">Regorxxx</a>')
 PLUGIN_DESCRIPTION = '''
 Tag files with tags from the AcousticBrainz database, all highlevel classifiers
 and tonal/rhythm data.
@@ -38,7 +39,7 @@ Based on code from Andrew Cook, Sambhav Kothari
 
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = "2.2.1"
+PLUGIN_VERSION = "2.2.2"
 PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
 
 # Plugin configuration
@@ -116,7 +117,9 @@ class TrackDataProcessor:
         self.data = self._extract_data(data)
         self.files = files
         self.do_simplemood = config.setting["acousticbrainz_add_simplemood"]
+        self.simplemood_tagname = config.setting["acousticbrainz_simplemood_tagname"]
         self.do_simplegenre = config.setting["acousticbrainz_add_simplegenre"]
+        self.simplegenre_tagname = config.setting["acousticbrainz_simplegenre_tagname"]
         self.do_keybpm = config.setting["acousticbrainz_add_keybpm"]
         self.do_fullhighlevel = config.setting["acousticbrainz_add_fullhighlevel"]
         self.do_sublowlevel = config.setting["acousticbrainz_add_sublowlevel"]
@@ -208,6 +211,7 @@ class TrackDataProcessor:
     def process_simplemood(self):
         self.debug("processing simplemood data")
 
+        mood_tagname = self.simplemood_tagname;
         moods = []
 
         for classifier, data in self.data.items():
@@ -217,11 +221,12 @@ class TrackDataProcessor:
                 if classifier.startswith("mood_") and not inverted:
                     moods.append(value)
 
-        self.update_metadata('mood', moods)
+        self.update_metadata(mood_tagname, moods)
 
     def process_simplegenre(self):
         self.debug("processing simplegenre data")
 
+        genre_tagname = self.simplegenre_tagname;
         genres = []
 
         for classifier, data in self.data.items():
@@ -231,7 +236,7 @@ class TrackDataProcessor:
                 if classifier.startswith("genre_") and not inverted:
                     genres.append(value)
 
-        self.update_metadata('genre', genres)
+        self.update_metadata(genre_tagname, genres)
 
     def process_fullhighlevel(self):
         self.debug("processing fullhighlevel data")
@@ -441,7 +446,9 @@ class AcousticBrainzOptionsPage(OptionsPage):
 
     options = [
         config.BoolOption("setting", "acousticbrainz_add_simplemood", True),
+        config.TextOption("setting", "acousticbrainz_simplemood_tagname", "ab:mood"),
         config.BoolOption("setting", "acousticbrainz_add_simplegenre", True),
+        config.TextOption("setting", "acousticbrainz_simplegenre_tagname", "ab:genre"),
         config.BoolOption("setting", "acousticbrainz_add_keybpm", False),
         config.BoolOption("setting", "acousticbrainz_add_fullhighlevel", False),
         config.BoolOption("setting", "acousticbrainz_add_sublowlevel", False)
@@ -455,7 +462,9 @@ class AcousticBrainzOptionsPage(OptionsPage):
     def load(self):
         setting = config.setting
         self.ui.add_simplemood.setChecked(setting["acousticbrainz_add_simplemood"])
+        self.ui.simplemood_tagname.setText(setting["acousticbrainz_simplemood_tagname"])
         self.ui.add_simplegenre.setChecked(setting["acousticbrainz_add_simplegenre"])
+        self.ui.simplegenre_tagname.setText(setting["acousticbrainz_simplegenre_tagname"])
         self.ui.add_fullhighlevel.setChecked(setting["acousticbrainz_add_fullhighlevel"])
         self.ui.add_keybpm.setChecked(setting["acousticbrainz_add_keybpm"])
         self.ui.add_sublowlevel.setChecked(setting["acousticbrainz_add_sublowlevel"])
@@ -463,7 +472,9 @@ class AcousticBrainzOptionsPage(OptionsPage):
     def save(self):
         setting = config.setting
         setting["acousticbrainz_add_simplemood"] = self.ui.add_simplemood.isChecked()
+        setting["acousticbrainz_simplemood_tagname"] = string_(self.ui.simplemood_tagname.text())
         setting["acousticbrainz_add_simplegenre"] = self.ui.add_simplegenre.isChecked()
+        setting["acousticbrainz_simplegenre_tagname"] = string_(self.ui.simplegenre_tagname.text())
         setting["acousticbrainz_add_keybpm"] = self.ui.add_keybpm.isChecked()
         setting["acousticbrainz_add_fullhighlevel"] = self.ui.add_fullhighlevel.isChecked()
         setting["acousticbrainz_add_sublowlevel"] = self.ui.add_sublowlevel.isChecked()

--- a/plugins/acousticbrainz/__init__.py
+++ b/plugins/acousticbrainz/__init__.py
@@ -472,9 +472,9 @@ class AcousticBrainzOptionsPage(OptionsPage):
     def save(self):
         setting = config.setting
         setting["acousticbrainz_add_simplemood"] = self.ui.add_simplemood.isChecked()
-        setting["acousticbrainz_simplemood_tagname"] = string_(self.ui.simplemood_tagname.text())
+        setting["acousticbrainz_simplemood_tagname"] = str(self.ui.simplemood_tagname.text())
         setting["acousticbrainz_add_simplegenre"] = self.ui.add_simplegenre.isChecked()
-        setting["acousticbrainz_simplegenre_tagname"] = string_(self.ui.simplegenre_tagname.text())
+        setting["acousticbrainz_simplegenre_tagname"] = str(self.ui.simplegenre_tagname.text())
         setting["acousticbrainz_add_keybpm"] = self.ui.add_keybpm.isChecked()
         setting["acousticbrainz_add_fullhighlevel"] = self.ui.add_fullhighlevel.isChecked()
         setting["acousticbrainz_add_sublowlevel"] = self.ui.add_sublowlevel.isChecked()

--- a/plugins/acousticbrainz/ui_options_acousticbrainz_tags.py
+++ b/plugins/acousticbrainz/ui_options_acousticbrainz_tags.py
@@ -26,9 +26,25 @@ class Ui_AcousticBrainzOptionsPage(object):
         self.add_simplemood = QtWidgets.QCheckBox(self.acousticbrainzTags_groupBox)
         self.add_simplemood.setObjectName("add_simplemood")
         self.verticalLayout_2.addWidget(self.add_simplemood)
+
+        self.simplemood_tagname_label = QtWidgets.QLabel(self.acousticbrainzTags_groupBox)
+        self.simplemood_tagname_label.setObjectName("simplemood_tagname_label")
+        self.verticalLayout_2.addWidget(self.simplemood_tagname_label)
+        self.simplemood_tagname = QtWidgets.QLineEdit(self.acousticbrainzTags_groupBox)
+        self.simplemood_tagname.setObjectName("simplemood_tagname")
+        self.verticalLayout_2.addWidget(self.simplemood_tagname)
+        
         self.add_simplegenre = QtWidgets.QCheckBox(self.acousticbrainzTags_groupBox)
         self.add_simplegenre.setObjectName("add_simplegenre")
         self.verticalLayout_2.addWidget(self.add_simplegenre)
+        
+        self.simplegenre_tagname_label = QtWidgets.QLabel(self.acousticbrainzTags_groupBox)
+        self.simplegenre_tagname_label.setObjectName("simplegenre_tagname_label")
+        self.verticalLayout_2.addWidget(self.simplegenre_tagname_label)
+        self.simplegenre_tagname = QtWidgets.QLineEdit(self.acousticbrainzTags_groupBox)
+        self.simplegenre_tagname.setObjectName("simplegenre_tagname")
+        self.verticalLayout_2.addWidget(self.simplegenre_tagname)
+        
         self.add_keybpm = QtWidgets.QCheckBox(self.acousticbrainzTags_groupBox)
         self.add_keybpm.setObjectName("add_keybpm")
         self.verticalLayout_2.addWidget(self.add_keybpm)
@@ -55,7 +71,9 @@ class Ui_AcousticBrainzOptionsPage(object):
         _translate = QtCore.QCoreApplication.translate
         self.acousticbrainzTags_groupBox.setTitle(_translate("AcousticBrainzOptionsPage", "AcousticBrainz Tags"))
         self.add_simplemood.setText(_translate("AcousticBrainzOptionsPage", "Add simple Mood tags"))
+        self.simplemood_tagname_label.setText(_translate("AcousticBrainzOptionsPage", "Mood tag name:"))
         self.add_simplegenre.setText(_translate("AcousticBrainzOptionsPage", "Add simple Genre tags"))
+        self.simplegenre_tagname_label.setText(_translate("AcousticBrainzOptionsPage", "Genre tag name:"))
         self.add_keybpm.setText(_translate("AcousticBrainzOptionsPage", "Add simple BPM and Key tags"))
         self.add_fullhighlevel.setText(_translate("AcousticBrainzOptionsPage", "Add all highlevel AcousticBrainz tags"))
         self.add_sublowlevel.setText(_translate("AcousticBrainzOptionsPage", "Add a subset of the lowlevel AcousticBrainz tags"))

--- a/plugins/acousticbrainz/ui_options_acousticbrainz_tags.ui
+++ b/plugins/acousticbrainz/ui_options_acousticbrainz_tags.ui
@@ -31,6 +31,16 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="simplemood_tagname_label">
+        <property name="text">
+         <string>Mood tag name:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="simplemood_tagname"/>
+      </item>
+      <item>
        <widget class="QCheckBox" name="add_simplegenre">
         <property name="text">
          <string>Add simple Genre tags</string>
@@ -38,6 +48,16 @@
        </widget>
       </item>
       <item>
+      <item>
+       <widget class="QLabel" name="simplegenre_tagname_label">
+        <property name="text">
+         <string>Genre tag name:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="simplegenre_tagname"/>
+      </item>
        <widget class="QCheckBox" name="add_keybpm">
         <property name="text">
          <string>Add simple BPM and Key tags</string>


### PR DESCRIPTION
Adds 2 edit boxes for mood and genre tag names. 

![image](https://user-images.githubusercontent.com/83307074/170235520-e5be123a-8ba5-4380-9bf4-bb9e4da7a6f3.png)

This should solve most issues with tag merging (for example with LastFM mood tag or genre tags provided by picard), since merging tags is trivial via script.

> $copymerge(mood,mood_lastfm) 
> $copymerge(mood,ab:mood) 
> $delete(ab:mood) 
> $delete(mood_lastfm) 

Also fixed author names, now point to email properly.

![image](https://user-images.githubusercontent.com/83307074/170235577-b8df7d22-017f-4048-b9c2-67f3633ffe4e.png)
