### PR TITLE
Mod files

### DIFF
--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -64,6 +64,9 @@ class ModuleFile(File):
     _magic = None
 
     # Specify the encoding for the format.
+    # There is not much info about encoding, most files seem to be limited
+    # to ASCII. But cp850 seems to be a solid default for the few files that
+    # use 8-bit characters.
     _encoding = 'cp850'  # or cp437?
 
     # List of StaticField. Most fields in mod files
@@ -148,6 +151,10 @@ class ExtendedModuleFile(ModuleFile):
 
     def _parse_file(self, f: RawIOBase, metadata: Metadata):
         super()._parse_file(f, metadata)
+        # OpenMPT seems to use iso-8859-1 encoding.
+        if metadata['encodedby'].startswith('OpenMPT'):
+            self._encoding = 'iso-8859-1'
+            super()._parse_file(f, metadata)
         f.seek(68)
         metadata['~channels'] = struct.unpack('<h', f.read(2))[0]
 

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -21,7 +21,7 @@ PLUGIN_NAME = 'MOD files'
 PLUGIN_AUTHOR = 'Philipp Wolfer'
 PLUGIN_DESCRIPTION = (
     'Support for loading and renaming various tracker files formats '
-    '(.mod, .xm, .it, .mptm, .ahx, .mtm, .med, .s3m, .okt). '
+    '(.mod, .xm, .it, .mptm, .ahx, .mtm, .med, .s3m, .ult, .699, .okt). '
     'There is limited support for writing the title tag as track name for some '
     'formats.'
 )
@@ -269,6 +269,28 @@ class S3MFile(ModuleFile):
     )
 
 
+class ULTFile(ModuleFile):
+    EXTENSIONS = ['.ult']
+    NAME = 'ULT'
+
+    # http://www.textfiles.com/programming/FORMATS/ultform.pro
+    # http://www.textfiles.com/programming/FORMATS/ultform14.pro
+    _magic = MagicBytes(b'MAS_UTrack_V00')
+    _static_text_fields = (
+        StaticField('title', 15, 32, FieldAccess.READ_WRITE),
+    )
+
+
+class Composer669File(ModuleFile):
+    EXTENSIONS = ['.669']
+    NAME = 'Composer 669'
+
+    # http://www.textfiles.com/programming/FORMATS/669-form.pro
+    _magic = MagicBytes(b'if')
+    _static_text_fields = (
+        StaticField('comment', 2, 108, FieldAccess.READ_WRITE),
+    )
+
 
 class OktalyzerFile(ModuleFile):
     EXTENSIONS = ['.okt']
@@ -286,4 +308,6 @@ register_format(AHXFile)
 register_format(MEDFile)
 register_format(MTMFile)
 register_format(S3MFile)
+register_format(ULTFile)
+register_format(Composer669File)
 register_format(OktalyzerFile)

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -21,7 +21,7 @@ PLUGIN_NAME = 'MOD files'
 PLUGIN_AUTHOR = 'Philipp Wolfer'
 PLUGIN_DESCRIPTION = (
     'Support for loading and renaming various tracker files formats '
-    '(.mod, .xm, .it, .ahx, .mtm, .med, .s3m). '
+    '(.mod, .xm, .it, .mptm, .ahx, .mtm, .med, .s3m, .okt). '
     'There is limited support for writing the title tag as track name for some '
     'formats.'
 )
@@ -268,6 +268,14 @@ class S3MFile(ModuleFile):
             raise ValueError('Not a %s file' % self.NAME)
 
 
+class OktalyzerFile(ModuleFile):
+    EXTENSIONS = ['.okt']
+    NAME = 'Oktalyzer'
+
+    # http://www.vgmpf.com/Wiki/index.php?title=OKT
+    _magic = b'OKTASONGCMOD'
+
+
 register_format(MODFile)
 register_format(ExtendedModuleFile)
 register_format(ImpulseTrackerFile)
@@ -276,3 +284,4 @@ register_format(AHXFile)
 register_format(MEDFile)
 register_format(MTMFile)
 register_format(S3MFile)
+register_format(OktalyzerFile)

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+PLUGIN_NAME = 'MOD formats'
+PLUGIN_AUTHOR = 'Philipp Wolfer'
+PLUGIN_DESCRIPTION = (
+    'Support for loading and renaming various tracker files formats '
+    '(.mod, .xm, .it).'
+)
+PLUGIN_VERSION = "0.1"
+PLUGIN_API_VERSIONS = ["2.8"]
+PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
+
+from dataclasses import dataclass
+from enum import Enum
+import struct
+
+from picard import log
+from picard.file import File
+from picard.formats import register_format
+from picard.metadata import Metadata
+from picard.util.textencoding import asciipunct
+
+
+class FieldAccess(Enum):
+    READ_ONLY = 0
+    READ_WRITE = 1
+
+
+@dataclass
+class StaticField:
+    name: str
+    offset: int
+    length: int
+    access: FieldAccess
+    fillchar: str = ' '
+
+
+class ModuleFile(File):
+    # Allows to specify a magic number to identify the file format.
+    # Re-implement _ensure_format for more complex cases.
+    _magic = None
+
+    # Specify the encoding for the format.
+    _encoding = 'cp850'  # or cp437?
+
+    # List of StaticField. Most fields in mod files
+    # have static position and fixed size.
+    _static_text_fields = ()
+
+    @classmethod
+    def supports_tag(cls, name):
+        return name in {field.name for field in cls._static_text_fields}
+
+    def _load(self, filename):
+        log.debug('Loading file %r', filename)
+        metadata = Metadata()
+        metadata['~format'] = self.NAME
+        self._add_path_to_metadata(metadata)
+        with open(filename, 'rb') as f:
+            self._ensure_format(f)
+            self._parse_file(f, metadata)
+        return metadata
+
+    def _save(self, filename, metadata):
+        log.debug('Saving file %r', filename)
+        with open(filename, 'rb+') as f:
+            self._ensure_format(f)
+            self._write_file(f, metadata)
+
+    def _ensure_format(self, f):
+        magic = self._magic
+        if not magic:
+            raise NotImplementedError('_magic not set or method not implemented')
+        id = f.read(len(magic))
+        if id != magic:
+            raise ValueError('Not a %s file' % self.NAME)
+
+    def _parse_file(self, f, metadata):
+        for field in self._static_text_fields:
+            f.seek(field.offset)
+            metadata[field.name] = self._decode_text(f.read(field.length))
+
+    def _write_file(self, f, metadata):
+        for field in self._static_text_fields:
+            if field.access == FieldAccess.READ_WRITE and not field.name.startswith('~'):
+                f.seek(field.offset)
+                f.write(self._encode_text(metadata[field.name], field.length, field.fillchar))
+
+    def _decode_text(self, data):
+        return data.decode(self._encoding, errors='replace').strip().strip('\0')
+
+    def _encode_text(self, text, length, fillchar=' '):
+        text = text[:length].ljust(length, fillchar)
+        return asciipunct(text).encode(self._encoding, errors='replace')
+
+
+class MODFile(ModuleFile):
+    EXTENSIONS = ['.mod']
+    NAME = 'MOD'
+
+    # https://www.ocf.berkeley.edu/~eek/index.html/tiny_examples/ptmod/ap12.html
+    _static_text_fields = (
+        StaticField('title', 0, 20, FieldAccess.READ_WRITE),
+    )
+
+    def _ensure_format(self, f):
+        magic = b'M\x2eK\x2e'
+        f.seek(1080)
+        id = f.read(4)
+        if id != magic:
+            raise ValueError('Not a %s file' % self.NAME)
+
+
+class ExtendedModuleFile(ModuleFile):
+    EXTENSIONS = ['.xm']
+    NAME = 'Extended Module'
+
+    # https://github.com/milkytracker/MilkyTracker/blob/master/resources/reference/xm-form.txt
+    _magic = b'Extended Module: '
+    _static_text_fields = (
+        StaticField('title', 17, 20, FieldAccess.READ_WRITE),
+        StaticField('encodedby', 38, 20, FieldAccess.READ_WRITE),
+    )
+
+    def _parse_file(self, f, metadata):
+        super()._parse_file(f, metadata)
+        f.seek(68)
+        metadata['~channels'] = struct.unpack('<h', f.read(2))[0]
+
+
+class ImpulseTrackerFile(ModuleFile):
+    EXTENSIONS = ['.it']
+    NAME = 'Impulse Tracker'
+
+    # https://fileformats.fandom.com/wiki/Impulse_tracker
+    _magic = b'IMPM'
+    _static_text_fields = (
+        StaticField('title', 4, 26, FieldAccess.READ_WRITE, '\0'),
+    )
+
+
+register_format(MODFile)
+register_format(ExtendedModuleFile)
+register_format(ImpulseTrackerFile)
+

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -104,14 +104,14 @@ class ModuleFile(File):
 
     def _ensure_format(self, f: RawIOBase) -> MagicBytes:
         if not self._magic_bytes:
-            raise NotImplementedError('_magic not set or method not implemented')
+            raise NotImplementedError('_magic_bytes not set or method not implemented')
         for magic in self._magic_bytes:
             f.seek(magic.offset)
-            id = f.read(len(magic))
-            if id == magic:
+            file_id = f.read(len(magic))
+            if file_id == magic:
                 return magic
-        else:
-            raise ValueError('Not a %s file' % self.NAME)
+        # None of the magic byte sequences matched, fail loading
+        raise ValueError('Not a %s file' % self.NAME)
 
     def _parse_file(self, f: RawIOBase, metadata: Metadata, magic: MagicBytes):
         for field in self._static_text_fields:
@@ -248,8 +248,7 @@ class MEDFile(ModuleFile):
     def _parse_file(self, f: RawIOBase, metadata: Metadata, magic: MagicBytes):
         # TODO: Extract songname
         super()._parse_file(f, metadata, magic)
-        format = self._decode_text(magic)
-        metadata['~format'] = self.NAME + ' (' + format + ')'
+        metadata['~format'] = '%s (%s)' % (self.NAME, self._decode_text(magic))
 
 
 class MTMFile(ModuleFile):
@@ -293,8 +292,7 @@ class ULTFile(ModuleFile):
 
     def _parse_file(self, f: RawIOBase, metadata: Metadata, magic: MagicBytes):
         super()._parse_file(f, metadata, magic)
-        format = self._decode_text(magic)
-        metadata['~format'] = self.NAME + ' (' + format + ')'
+        metadata['~format'] = '%s (%s)' % (self.NAME, self._decode_text(magic))
 
 
 class Composer669File(ModuleFile):

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -61,7 +61,7 @@ class StaticField:
 class MagicBytes(bytes):
     offset: int = 0
 
-    def __new__(cls, value, offset: int=0):
+    def __new__(cls, value, offset: int = 0):
         self = super().__new__(cls, value)
         self.offset = offset
         return self
@@ -130,7 +130,7 @@ class ModuleFile(File):
     def _decode_text(self, data: bytes) -> str:
         return data.decode(self._encoding, errors='replace').strip().strip('\0')
 
-    def _encode_text(self, text: str, length: int=None, fillchar: str=' ') -> bytes:
+    def _encode_text(self, text: str, length: int = None, fillchar: str = ' ') -> bytes:
         if length:
             text = text[:length].ljust(length, fillchar)
         return asciipunct(text).encode(self._encoding, errors='replace')

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -209,13 +209,10 @@ class AHXFile(ModuleFile):
 
     def _seek_names_offset(self, f: RawIOBase) -> int:
         f.seek(6)
-        len = struct.unpack('>H', f.read(2))[0] & 0xfff
+        len_ = struct.unpack('>H', f.read(2))[0] & 0xfff
         f.seek(10)
-        trl = struct.unpack('B', f.read(1))[0]
-        trk = struct.unpack('B', f.read(1))[0]
-        smp = struct.unpack('B', f.read(1))[0]
-        ss = struct.unpack('B', f.read(1))[0]
-        samples_offset = 14 + ss*2 + len*8 + (trk+1)*trl*3
+        trl, trk, smp, ss = struct.unpack('BBBB', f.read(4))
+        samples_offset = 14 + ss*2 + len_*8 + (trk+1)*trl*3
         f.seek(samples_offset)
         self._skip_samples(f, count=smp)
         return f.tell()

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -180,6 +180,7 @@ class OpenMPTFile(ImpulseTrackerFile):
     # https://wiki.openmpt.org/Manual:_Module_formats#The_OpenMPT_format_.28.mptm.29
     EXTENSIONS = ['.mptm']
     NAME = 'OpenMPT'
+    _encoding = 'iso-8859-1'
 
 
 class AHXFile(ModuleFile):

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -20,10 +20,10 @@
 PLUGIN_NAME = 'MOD files'
 PLUGIN_AUTHOR = 'Philipp Wolfer'
 PLUGIN_DESCRIPTION = (
-    'Support for loading and renaming various tracker files formats '
+    'Support for loading and renaming various tracker module formats '
     '(.mod, .xm, .it, .mptm, .ahx, .mtm, .med, .s3m, .ult, .699, .okt). '
-    'There is limited support for writing the title tag as track name for some '
-    'formats.'
+    'There is limited support for writing the title tag as track name for '
+    'some formats.'
 )
 PLUGIN_VERSION = "0.1"
 PLUGIN_API_VERSIONS = ["2.8"]

--- a/plugins/mod/__init__.py
+++ b/plugins/mod/__init__.py
@@ -58,16 +58,13 @@ class StaticField:
     fillchar: str = ' '
 
 
-@dataclass
-class MagicBytes:
-    id: bytes
+class MagicBytes(bytes):
     offset: int = 0
 
-    def __len__(self):
-        return len(self.id)
-
-    def __eq__(self, other) -> bool:
-        return self.id == other
+    def __new__(cls, value, offset: int=0):
+        self = super().__new__(cls, value)
+        self.offset = offset
+        return self
 
 
 class ModuleFile(File):
@@ -251,7 +248,7 @@ class MEDFile(ModuleFile):
     def _parse_file(self, f: RawIOBase, metadata: Metadata, magic: MagicBytes):
         # TODO: Extract songname
         super()._parse_file(f, metadata, magic)
-        format = self._decode_text(magic.id)
+        format = self._decode_text(magic)
         metadata['~format'] = self.NAME + ' (' + format + ')'
 
 
@@ -296,7 +293,7 @@ class ULTFile(ModuleFile):
 
     def _parse_file(self, f: RawIOBase, metadata: Metadata, magic: MagicBytes):
         super()._parse_file(f, metadata, magic)
-        format = self._decode_text(magic.id)
+        format = self._decode_text(magic)
         metadata['~format'] = self.NAME + ' (' + format + ')'
 
 


### PR DESCRIPTION
This adds support for loading various tracker module formats. Loading and saving the songname (as `title` tag) is supported for most of the formats that support storing this information in the file.

Calculation of playback duration is currently not implemented. This could be added in the future, but requires more extensive parsing of the various formats (including in some cases several different format versions).

I tested this with some files from my collection and additional files in various formats from https://modarchive.org/