### PR TITLE
replaygain2: provide browse button to set path to rsgain command

### DIFF
--- a/plugins/replaygain2/__init__.py
+++ b/plugins/replaygain2/__init__.py
@@ -29,7 +29,7 @@ The following file formats are supported:
 
 This plugin is based on the original ReplayGain plugin by Philipp Wolfer and Sophist.
 '''
-PLUGIN_VERSION = "1.0"
+PLUGIN_VERSION = "1.1"
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -38,6 +38,8 @@ from functools import partial
 import subprocess  # nosec: B404
 import shutil
 import os
+
+from PyQt5.QtWidgets import QFileDialog
 
 from picard import log
 from picard.formats.vorbis import OggOpusFile
@@ -357,6 +359,7 @@ class ReplayGain2OptionsPage(OptionsPage):
             N_("Write standard ReplayGain tags"),
             N_("Write R128_*_GAIN tags")
         ])
+        self.ui.rsgain_command_browse.clicked.connect(self.rsgain_command_browse)
 
     def load(self):
         self.ui.rsgain_command.setText(self.config.setting["rsgain_command"])
@@ -379,6 +382,12 @@ class ReplayGain2OptionsPage(OptionsPage):
         self.config.setting["max_peak"] = self.ui.max_peak.value()
         self.config.setting["opus_mode"] = self.ui.opus_mode.currentIndex()
         self.config.setting["opus_m23"] = self.ui.opus_m23.isChecked()
+
+    def rsgain_command_browse(self):
+        path, _filter = QFileDialog.getOpenFileName(self, "", self.ui.rsgain_command.text())
+        if path:
+            path = os.path.normpath(path)
+            self.ui.rsgain_command.setText(path)
 
 
 register_track_action(ScanTracks())

--- a/plugins/replaygain2/ui_options_replaygain2.py
+++ b/plugins/replaygain2/ui_options_replaygain2.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'ui_options_replaygain2.ui'
+# Form implementation generated from reading ui file 'plugins/replaygain2/ui_options_replaygain2.ui'
 #
 # Created by: PyQt5 UI code generator 5.15.7
 #
@@ -37,9 +37,15 @@ class Ui_ReplayGain2OptionsPage(object):
         self.label.setFont(font)
         self.label.setObjectName("label")
         self.vboxlayout1.addWidget(self.label)
+        self.horizontalLayout = QtWidgets.QHBoxLayout()
+        self.horizontalLayout.setObjectName("horizontalLayout")
         self.rsgain_command = QtWidgets.QLineEdit(self.replay_gain)
         self.rsgain_command.setObjectName("rsgain_command")
-        self.vboxlayout1.addWidget(self.rsgain_command)
+        self.horizontalLayout.addWidget(self.rsgain_command)
+        self.rsgain_command_browse = QtWidgets.QToolButton(self.replay_gain)
+        self.rsgain_command_browse.setObjectName("rsgain_command_browse")
+        self.horizontalLayout.addWidget(self.rsgain_command_browse)
+        self.vboxlayout1.addLayout(self.horizontalLayout)
         self.label_6 = QtWidgets.QLabel(self.replay_gain)
         self.label_6.setOpenExternalLinks(True)
         self.label_6.setTextInteractionFlags(QtCore.Qt.TextBrowserInteraction)
@@ -143,6 +149,7 @@ class Ui_ReplayGain2OptionsPage(object):
         self.replay_gain.setTitle(_translate("ReplayGain2OptionsPage", "ReplayGain 2.0 Settings"))
         self.label.setText(_translate("ReplayGain2OptionsPage", "Path to rsgain:"))
         self.rsgain_command.setText(_translate("ReplayGain2OptionsPage", "rsgain"))
+        self.rsgain_command_browse.setText(_translate("ReplayGain2OptionsPage", "Browse..."))
         self.label_6.setText(_translate("ReplayGain2OptionsPage", "<a href=\"https://github.com/complexlogic/rsgain\">Download rsgain</a>"))
         self.album_tags.setText(_translate("ReplayGain2OptionsPage", "Calculate album gain/peak"))
         self.true_peak.setWhatsThis(_translate("ReplayGain2OptionsPage", "Use more accurate true peak calculations (trade for performance)"))

--- a/plugins/replaygain2/ui_options_replaygain2.ui
+++ b/plugins/replaygain2/ui_options_replaygain2.ui
@@ -67,11 +67,22 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="rsgain_command">
-        <property name="text">
-         <string>rsgain</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLineEdit" name="rsgain_command">
+          <property name="text">
+           <string>rsgain</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QToolButton" name="rsgain_command_browse">
+          <property name="text">
+           <string>Browse...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QLabel" name="label_6">


### PR DESCRIPTION
Users have trouble setting the path for rsgain command. Provide a browse button to allow users setting the path using a file chooser dialog.