### PR TITLE
Rename workflow jobs...

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  build:
+  unittest:
 
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
... so it is clear that they are unittest jobs and not executable build jobs.