### PR TITLE
Update acousticbrainz plugins to correctly use a 1s rate limit.

### DIFF
--- a/plugins/acousticbrainz/__init__.py
+++ b/plugins/acousticbrainz/__init__.py
@@ -39,7 +39,7 @@ Based on code from Andrew Cook, Sambhav Kothari
 
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = "2.2.2"
+PLUGIN_VERSION = "2.2.3"
 PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
 
 # Plugin configuration
@@ -80,7 +80,7 @@ from picard.ui.options import (
 from picard.webservice import ratecontrol
 from picard.plugins.acousticbrainz.ui_options_acousticbrainz_tags import Ui_AcousticBrainzOptionsPage
 
-ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 250)
+ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 1000)
 
 # Constants
 # =============================================================================

--- a/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
+++ b/plugins/acousticbrainz_tonal-rhythm/acousticbrainz_tonal-rhythm.py
@@ -29,7 +29,7 @@ plugin instead.</em>
 '''
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = '1.1.5'
+PLUGIN_VERSION = '1.1.6'
 PLUGIN_API_VERSIONS = ["2.0"]  # Requires support for TKEY which is in 1.4
 
 from json import JSONDecodeError
@@ -43,7 +43,7 @@ from picard.util import load_json
 ACOUSTICBRAINZ_HOST = "acousticbrainz.org"
 ACOUSTICBRAINZ_PORT = 80
 
-ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 100)
+ratecontrol.set_minimum_delay((ACOUSTICBRAINZ_HOST, ACOUSTICBRAINZ_PORT), 1000)
 
 
 class AcousticBrainz_Key:


### PR DESCRIPTION
Actual acousticbrainz rate limit is [10 requests every 10s](https://acousticbrainz.readthedocs.io/api.html#rate-limiting)