### PR TITLE
Add "as credited" sort variables to "Additional Artists Variables"

### DIFF
--- a/plugins/additional_artists_variables/additional_artists_variables.py
+++ b/plugins/additional_artists_variables/additional_artists_variables.py
@@ -46,6 +46,10 @@ from picard.metadata import (register_album_metadata_processor,
 from picard.plugin import PluginPriority
 
 
+ID_ALIASES_ARTIST_NAME = '894afba6-2816-3c24-8072-eadb66bd04bc'
+ID_ALIASES_LEGAL_NAME = 'd4dcd0c0-b341-3612-a332-c0ce797b25cf'
+
+
 def process_artists(album_id, source_metadata, destination_metadata, source_type):
     # Test for valid metadata node.
     # The 'artist-credit' key should always be there.
@@ -115,13 +119,13 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
                     metadata_error(album_id, 'artist-credit.artist.type', source_type)
                 if 'aliases' in artist_credit['artist']:
                     for item in artist_credit['artist']['aliases']:
-                        if 'type-id' in item and item['type-id'] =='d4dcd0c0-b341-3612-a332-c0ce797b25cf':
+                        if 'type-id' in item and item['type-id'] == ID_ALIASES_LEGAL_NAME:
                             if 'ended' in item and not item['ended']:
                                 if 'name' in item:
                                     temp_legal_name = item['name']
                                 if 'sort-name' in item:
                                     temp_legal_sort_name = item['sort-name']
-                        if 'type-id' in item and item['type-id'] == '894afba6-2816-3c24-8072-eadb66bd04bc':
+                        if 'type-id' in item and item['type-id'] == ID_ALIASES_ARTIST_NAME:
                             if 'name' in item and 'sort-name' in item and str(item['name']).lower() == temp_cred_name.lower():
                                 temp_cred_sort_name = item['sort-name']
                 tag_list = []
@@ -261,7 +265,7 @@ def make_track_vars(album, album_metadata, track_metadata, release_metadata):
 
 def metadata_error(album_id, metadata_element, metadata_group):
     log.error("{0}: {1!r}: Missing '{2}' in {3} metadata.".format(
-            PLUGIN_NAME, album_id, metadata_element, metadata_group,))
+        PLUGIN_NAME, album_id, metadata_element, metadata_group,))
 
 
 # Register the plugin to run at a LOW priority so that other plugins that


### PR DESCRIPTION
Add the following new variables to the "Additional Artists Variables" plugin in response to the "[Is there a way to get a renamed Artist’s alias’s sort order in Picard?](https://community.metabrainz.org/t/is-there-a-way-to-get-a-renamed-artists-aliass-sort-order-in-picard/670245)" discussion on the community forum.

### Album Variables

* **_artists_album_primary_cred_sort** - The primary / first album artist listed (sort name as credited)
* **_artists_album_additional_cred_sort** - All album artists listed (sort names as credited) except for the primary / first artist, separated by strings provided from the release entry
* **_artists_album_additional_cred_sort_multi** - All album artists listed (sort names as credited) except for the primary / first artist, as a multi-value
* **_artists_album_all_cred_sort** - All album artists listed (sort names as credited), separated by strings provided from the release entry
* **_artists_album_all_cred_sort_multi** - All album artists listed (sort names as credited), as a multi-value

### Track Variables

* **_artists_track_primary_cred_sort** - The primary / first track artist listed (sort as credited name)
* **_artists_track_additional_cred_sort** - All track artists listed (sort names as credited) except for the primary / first artist, separated by strings provided from the track entry
* **_artists_track_additional_cred_sort_multi** - All track artists listed (sort names as credited) except for the primary / first artist, as a multi-value
* **_artists_track_all_cred_sort** - All track artists listed (sort names as credited), separated by strings provided from the track entry
* **_artists_track_all_cred_sort_multi** - All track artists listed (sort names as credited), as a multi-value

The cred sort values are taken as the sort name from the alias that matches the "as credited" name if it exists, otherwise the sort name from the artist (standardized name).
