### PR TITLE
PICARD-2821: Playlist: Fix crash if playlist and audio file are on different drives

### DIFF
--- a/plugins/playlist/playlist.py
+++ b/plugins/playlist/playlist.py
@@ -16,7 +16,7 @@ PLUGIN_AUTHOR = "Francis Chin, Sambhav Kothari, Chris Hylen"
 PLUGIN_DESCRIPTION = """Generate an Extended M3U playlist (.m3u8 file, UTF8
 encoded text). Relative pathnames are used where audio files are in the same
 directory as the playlist, otherwise absolute (full) pathnames are used."""
-PLUGIN_VERSION = "1.2"
+PLUGIN_VERSION = "1.2.1"
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -83,7 +83,10 @@ class GeneratePlaylist(BaseAction):
                 if track.linked_files:
                     files.append(track.linked_files[0].filename)
 
-        current_directory = os.path.commonpath(files)
+        try:
+            current_directory = os.path.commonpath(files)
+        except ValueError:
+            current_directory = ""
 
         # Default playlist filename set as "%albumartist% - %album%.m3u8",
         # except where "Various Artists" is suppressed
@@ -140,7 +143,10 @@ class GeneratePlaylist(BaseAction):
                             log.debug("{}: audio_filename: {}, selected dir: {}".format(
                                     PLUGIN_NAME, audio_filename, os.path.dirname(filename)))
 
-                        audio_filename = os.path.relpath(audio_filename, os.path.dirname(filename))
+                        try:
+                            audio_filename = os.path.relpath(audio_filename, os.path.dirname(filename))
+                        except ValueError:
+                            pass
                         entry.add(str(audio_filename))
 
             playlist.write()


### PR DESCRIPTION
Fixes crash on Windows in playlist plugin if audio file and playlist are on different drives.

See PICARD-2821

https://docs.python.org/3/library/os.path.html#os.path.commonpath
https://docs.python.org/3/library/os.path.html#os.path.relpath