### PR TITLE
Added losslessfuncs plugin

### DIFF
--- a/plugins/formathelpers/__init__.py
+++ b/plugins/formathelpers/__init__.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014 Philipp Wolfer
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+PLUGIN_NAME = 'Tagger script format helper functions'
+PLUGIN_AUTHOR = 'Philipp Wolfer'
+PLUGIN_DESCRIPTION = 'A collection of useful functions to deal with file formats.'
+PLUGIN_VERSION = "0.1"
+PLUGIN_API_VERSIONS = ["1.3.0", "2.0"]
+
+from picard.script import register_script_function
+
+LOSSLESS_EXTENSIONS = ['flac', 'oggflac', 'ape', 'ofr', 'tak', 'wv', 'tta']
+
+
+def is_lossless(parser):
+    """
+    Returns true, if the file processed is a lossless audio format.
+    Note: This depends mainly on the file extension and does not look inside
+    the file to detect the codec.
+    """
+    if parser.context['~extension'] in LOSSLESS_EXTENSIONS:
+        return "1"
+    elif parser.context['~extension'] == 'm4a':
+        # Mutagen < 1.26 fails to detect the bitrate
+        # for Apple Lossless Audio Codec.
+        if not parser.context['~bitrate'] or float(parser.context['~bitrate']) > 1000:
+            return "1"
+        else:
+            return ""
+    else:
+        return ""
+
+
+def is_lossy(parser):
+    """Returns true, if the file processed is a lossy audio format."""
+    if is_lossless(parser) == "1":
+        return ""
+    else:
+        return "1"
+
+
+register_script_function(is_lossless)
+register_script_function(is_lossy)

--- a/plugins/losslessfuncs/__init__.py
+++ b/plugins/losslessfuncs/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014, 2017, 2021 Philipp Wolfer
+# Copyright (C) 2014, 2017, 2021, 2023-2024 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -19,8 +19,8 @@
 PLUGIN_NAME = 'Tagger script functions $is_lossless() and $is_lossy()'
 PLUGIN_AUTHOR = 'Philipp Wolfer'
 PLUGIN_DESCRIPTION = 'Tagger script functions to detect if a file is lossless or lossy'
-PLUGIN_VERSION = "0.2"
-PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
+PLUGIN_VERSION = "0.3"
+PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11"]
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
@@ -41,20 +41,21 @@ def is_lossless(parser):
         return "1"
     elif parser.context['~extension'] == 'm4a':
         # Mutagen < 1.26 fails to detect the bitrate for Apple Lossless Audio Codec.
-        if not parser.context['~bitrate'] or parser.context['~bitrate'] > 1000:
+        if not parser.context['~bitrate']:
             return "1"
         else:
-            return ""
+            try:
+                bitrate = float(parser.context['~bitrate'])
+                return "1" if bitrate > 1000 else ""
+            except (TypeError, ValueError):
+                return ""
     else:
         return ""
 
 
 def is_lossy(parser):
     """Returns true, if the file processed is a lossy audio format."""
-    if is_lossless(parser) == "1":
-        return ""
-    else:
-        return "1"
+    return "" if is_lossless(parser) == "1" else "1"
 
 
 register_script_function(is_lossless)

--- a/plugins/losslessfuncs/__init__.py
+++ b/plugins/losslessfuncs/__init__.py
@@ -25,8 +25,8 @@ PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
 
 
-LOSSLESS_EXTENSIONS = ['flac', 'oggflac', 'ape', 'ofr', 'tak', 'wv', 'tta',
-                       'aiff', 'aif', 'wav']
+LOSSLESS_EXTENSIONS = {'flac', 'oggflac', 'ape', 'ofr', 'tak', 'wv', 'tta',
+                       'aiff', 'aif', 'wav'}
 
 from picard.script import register_script_function
 

--- a/plugins/losslessfuncs/__init__.py
+++ b/plugins/losslessfuncs/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014 Philipp Wolfer
+# Copyright (C) 2014, 2017, 2021 Philipp Wolfer
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -16,29 +16,32 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-PLUGIN_NAME = 'Tagger script format helper functions'
+PLUGIN_NAME = 'Tagger script functions $is_lossless() and $is_lossy()'
 PLUGIN_AUTHOR = 'Philipp Wolfer'
-PLUGIN_DESCRIPTION = 'A collection of useful functions to deal with file formats.'
-PLUGIN_VERSION = "0.1"
-PLUGIN_API_VERSIONS = ["1.3.0", "2.0"]
+PLUGIN_DESCRIPTION = 'Tagger script functions to detect if a file is lossless or lossy'
+PLUGIN_VERSION = "0.2"
+PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
+PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
+
+
+LOSSLESS_EXTENSIONS = ['flac', 'oggflac', 'ape', 'ofr', 'tak', 'wv', 'tta',
+                       'aiff', 'aif', 'wav']
 
 from picard.script import register_script_function
-
-LOSSLESS_EXTENSIONS = ['flac', 'oggflac', 'ape', 'ofr', 'tak', 'wv', 'tta']
 
 
 def is_lossless(parser):
     """
     Returns true, if the file processed is a lossless audio format.
-    Note: This depends mainly on the file extension and does not look inside
-    the file to detect the codec.
+    Note: This depends mainly on the file extension and does not look inside the
+    file to detect the codec.
     """
     if parser.context['~extension'] in LOSSLESS_EXTENSIONS:
         return "1"
     elif parser.context['~extension'] == 'm4a':
-        # Mutagen < 1.26 fails to detect the bitrate
-        # for Apple Lossless Audio Codec.
-        if not parser.context['~bitrate'] or float(parser.context['~bitrate']) > 1000:
+        # Mutagen < 1.26 fails to detect the bitrate for Apple Lossless Audio Codec.
+        if not parser.context['~bitrate'] or parser.context['~bitrate'] > 1000:
             return "1"
         else:
             return ""


### PR DESCRIPTION
This adds two helper functions `$is_lossless()`  and `$is_lossy()` to help tagging files depending on whether they are in a lossy or lossless format.

The detection is not actually based on the audio codec but uses formats and some heuristics. While not perfect and does the right thing in the majority of cases and it is an essential part of my file naming script for years. The limitation would be a reason for me not to include it in Picard itself, but as a plugin I think it is fine.

The plugin is already in active use by others as well, see the discussions in the forums:

https://community.metabrainz.org/t/categorizing-lossless-music/258530/
https://community.metabrainz.org/t/is-lossless-plugin-no-longer-working-with-m4a/469429
