### PR TITLE
Genre Mapper invalid regex exception handling

### DIFF
--- a/plugins/genre_mapper/__init__.py
+++ b/plugins/genre_mapper/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2022-2023 Bob Swift (rdswift)
+# Copyright (C) 2022-2024 Bob Swift (rdswift)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -28,8 +28,8 @@ plugin is configured.
 <br /><br />
 Please see the <a href="https://github.com/rdswift/picard-plugins/blob/2.0_RDS_Plugins/plugins/genre_mapper/docs/README.md">user guide</a> on GitHub for more information.
 '''
-PLUGIN_VERSION = '0.5'
-PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2', '2.3', '2.6', '2.7', '2.8', '2.9']
+PLUGIN_VERSION = '0.6'
+PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2', '2.3', '2.6', '2.7', '2.8', '2.9', '2.10', '2.11']
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
 
@@ -147,21 +147,24 @@ def track_genre_mapper(album, metadata, *args):
     if not config.setting[OPT_MATCH_ENABLED]:
         return
     if 'genre' not in metadata or not metadata['genre']:
-        log.debug("%s: No genres found for: \"%s\"", PLUGIN_NAME, metadata['title'],)
+        log.debug('%s: No genres found for: "%s"', PLUGIN_NAME, metadata['title'],)
         return
     genre_joiner = config.setting[OPT_GENRE_SEPARATOR] if config.setting[OPT_GENRE_SEPARATOR] else MULTI_VALUED_JOINER
     genres = set()
     metadata_genres = str(metadata['genre']).split(genre_joiner)
     for genre in metadata_genres:
         for (original, replacement) in GenreMappingPairs.pairs:
-            if genre and re.search(original, genre, re.IGNORECASE):
-                genre = replacement
-                if config.setting[OPT_MATCH_FIRST]:
-                    break
+            try:
+                if genre and re.search(original, genre, re.IGNORECASE):
+                    genre = replacement
+                    if config.setting[OPT_MATCH_FIRST]:
+                        break
+            except re.error:
+                log.error('%s: Invalid regular expression ignored: "%s"', PLUGIN_NAME, original,)
         if genre:
             genres.add(genre.title())
     genres = sorted(genres)
-    log.debug("{0}: Genres updated from {1} to {2}".format(PLUGIN_NAME, metadata_genres, genres,))
+    log.debug('%s: Genres updated from %s to %s', PLUGIN_NAME, metadata_genres, genres,)
     metadata['genre'] = genres
 
 


### PR DESCRIPTION
Further to the discussion in the [Community Forum](https://community.metabrainz.org/t/proposed-genre-mapping-plugin/528398/24) this pull request includes an update to the Genre Mapper plugin to trap the invalid regex exception and create a log entry showing that the invalid regex has been ignored.  It also cleans up some of the logging calls.
