### PR TITLE
Add "mood" tag to excluded tag list

### DIFF
--- a/plugins/sort_multivalue_tags/sort_multivalue_tags.py
+++ b/plugins/sort_multivalue_tags/sort_multivalue_tags.py
@@ -23,7 +23,7 @@ Note: Some multi-value tags are excluded for the following reasons:
 <li>The sequence of one tag is linked to the sequence of another e.g. Label and Catalogue number.</li>
 </ol>
 '''
-PLUGIN_VERSION = "1.0"
+PLUGIN_VERSION = "1.1"
 PLUGIN_API_VERSIONS = ["0.15", "2.0"]
 PLUGIN_LICENSE = "GPL-2.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
@@ -40,6 +40,7 @@ _sort_multivalue_tags_exclude = (
     'label', 'catalognumber',
     'country', 'date',
     'releasetype',
+    'mood',
 )
 # Possible future enhancement:
 # Sort linked tags e.g. work so that the sequence in related tags e.g. workid retains the relationship between


### PR DESCRIPTION
The mood tag set by the AcoustBrainz plugin has values which are either e.g. "Not happy" or "Happy".

We do not want these sorted alphabetically but instead left in the same order as they are presented by AcoustBrainz.

Note: The tag name is "mood" by default, but the user can change it in the ui. If the user changes it this exclusion will not be effective.