### PR TITLE
deezerart: fixed crash if artist similarity is below threshold

### DIFF
--- a/plugins/deezerart/__init__.py
+++ b/plugins/deezerart/__init__.py
@@ -1,7 +1,7 @@
 PLUGIN_NAME = "Deezer cover art"
 PLUGIN_AUTHOR = "Fabio Forni <livingsilver94>"
 PLUGIN_DESCRIPTION = "Fetch cover arts from Deezer"
-PLUGIN_VERSION = '1.2.1'
+PLUGIN_VERSION = '1.2.2'
 PLUGIN_API_VERSIONS = ['2.5']
 PLUGIN_LICENSE = "GPL-3.0-or-later"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-3.0.html"
@@ -130,7 +130,7 @@ class Provider(providers.CoverArtProvider):
                 if not isinstance(result, obj.Track):
                     continue
                 if not is_similar(artist, result.artist.name, min_similarity):
-                    self.log_debug('artist similarity below threshold: %r ~ %r', artist, result.artist.title)
+                    self.log_debug('artist similarity below threshold: %r ~ %r', artist, result.artist.name)
                     continue
                 if not is_similar(album, result.album.title, min_similarity):
                     self.log_debug('album similarity below threshold: %r ~ %r', album, result.album.title)


### PR DESCRIPTION
If the artist similarity is below the configured threshold the plugin crashed with:

```
Traceback (most recent call last):
  File "/tmp/.mount_MusicBdwLOgu/usr/conda/lib/python3.12/site-packages/picard/webservice/__init__.py", line 593, in _process_reply
    self._handle_reply(reply, request)
  File "/tmp/.mount_MusicBdwLOgu/usr/conda/lib/python3.12/site-packages/picard/webservice/__init__.py", line 581, in _handle_reply
    handler(bytes(reply.readAll()), reply, error)
  File "/home/phw/Applications/MusicBrainz-Picard-daily-x86_64.AppImage.config/MusicBrainz/Picard/plugins/deezerart/deezer/client.py", line 57, in handler
    callback(result, error)
  File "/home/phw/Applications/MusicBrainz-Picard-daily-x86_64.AppImage.config/MusicBrainz/Picard/plugins/deezerart/__init__.py", line 133, in _queue_from_search
    self.log_debug('artist similarity below threshold: %r ~ %r', artist, result.artist.title)
                                                                         ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Artist' object has no attribute 'title'
Aborted (core dumped)
```