### PR TITLE
fix(bpm): Only update file in callback

### DIFF
--- a/plugins/bpm/__init__.py
+++ b/plugins/bpm/__init__.py
@@ -73,10 +73,10 @@ class FileBPM(BaseAction):
         if self._close:
             return
         file.metadata["bpm"] = str(round(calculated_bpm, 1))
-        file.update()
 
     def _calculate_bpm_callback(self, file, result=None, error=None):
         if not error:
+            file.update()
             self.tagger.window.set_statusbar_message(
                 N_('BPM for "%(filename)s" successfully calculated.'),
                 {'filename': file.filename}

--- a/plugins/bpm/__init__.py
+++ b/plugins/bpm/__init__.py
@@ -13,7 +13,7 @@ PLUGIN_AUTHOR = "Len Joubert, Sambhav Kothari, Philipp Wolfer"
 PLUGIN_DESCRIPTION = """Calculate BPM for selected files and albums. Linux only version with dependancy on Aubio and Numpy"""
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
-PLUGIN_VERSION = "1.5.1"
+PLUGIN_VERSION = "1.5.2"
 PLUGIN_API_VERSIONS = ["2.0"]
 # PLUGIN_INCOMPATIBLE_PLATFORMS = [
 #    'win32', 'cygwyn', 'darwin', 'os2', 'os2emx', 'riscos', 'atheos']


### PR DESCRIPTION
When using the `bpm` plugin, I've observed a bug where after using this plugin, where Picard would freeze after updates. This PR apparently resolves it, by moving the `update` call into the callback instead of in the initial call