### PR TITLE
fix: lowercase ident

### DIFF
--- a/plugins/critiquebrainz/critiquebrainz.py
+++ b/plugins/critiquebrainz/critiquebrainz.py
@@ -59,7 +59,7 @@ def result_review(album, metadata, data, reply, error):
         if reviews:
             for review in reviews:
                 if "last_revision" in review:
-                    ident = review["entity_type"].replace("_", "-") + "_review_" + review["published_on"] + "_" + review["user"]["display_name"] + "_" + review["language"]
+                    ident = (review["entity_type"].replace("_", "-") + "_review_" + review["published_on"] + "_" + review["user"]["display_name"] + "_" + review["language"]).lower()
                     if review["last_revision"]["text"] is not None:
                         review_text = review["last_revision"]["text"] + "\n\nEine Bewertung mit " + str(review["last_revision"]["rating"]) + " von 5 Sternen veröffentlich durch " + review["user"]["display_name"] + " am " + review["published_on"] + " lizensiert unter " + review["full_name"] + ".";
                         if "comment:" + ident in metadata:

--- a/plugins/critiquebrainz/critiquebrainz.py
+++ b/plugins/critiquebrainz/critiquebrainz.py
@@ -32,7 +32,7 @@ Recording:
  https://critiquebrainz.org/recording/93113326-93e9-409c-a3d6-5ec91864ba30'''
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"
-PLUGIN_VERSION = "1.0.1"
+PLUGIN_VERSION = "1.0.2"
 PLUGIN_API_VERSIONS = ["2.0"]
 
 from functools import partial


### PR DESCRIPTION
The variable `ident` contains a string with upper and lower case letters. When saving in Picard, this causes everything in the resulting tag to be converted to lower case. The next time the album or track is refreshed, a difference is now detected because the plugin returns upper and lower case. Picard compares with the existing tag, which is only written in lower case. The result is that the lower case tag is deleted and replaced with a mixed case tag.