### PR TITLE
Sort collection list alphabetically

### DIFF
--- a/plugins/add_to_collection/manifest.py
+++ b/plugins/add_to_collection/manifest.py
@@ -1,7 +1,7 @@
 PLUGIN_NAME = "Add to Collection"
 PLUGIN_AUTHOR = "Dvir Yitzchaki (dvirtz@gmail.com)"
 PLUGIN_DESCRIPTION = "Adds any saved release to one of your user collections"
-PLUGIN_VERSION = "0.1.1"
+PLUGIN_VERSION = "0.1.2"
 PLUGIN_API_VERSIONS = ["2.0"]
 PLUGIN_LICENSE = ("MIT",)
 PLUGIN_LICENSE_URL = "https://spdx.org/licenses/MIT.html"

--- a/plugins/add_to_collection/options.py
+++ b/plugins/add_to_collection/options.py
@@ -30,7 +30,7 @@ class AddToCollectionOptionsPage(OptionsPage):
     def set_collection_name(self, value: str) -> None:
         self.ui.collection_name.clear()
         collection: Collection
-        for collection in user_collections.values():
+        for collection in sorted(user_collections.values(), key=lambda c: c.name.lower()):
             self.ui.collection_name.addItem(collection.name, collection.id)
         idx = self.ui.collection_name.findData(value)
         if idx != -1:


### PR DESCRIPTION
The dropdown list of user collections on the plugin's options
page was previously unsorted, making it difficult to find
a specific collection in a long list.

This change sorts the list case-insensitively by collection
name to improve usability.

_Note: Description and code AI-written_