### PR TITLE
Search Engine Lookup: Additional words setting not saving

### DIFF
--- a/plugins/search_engine_lookup/__init__.py
+++ b/plugins/search_engine_lookup/__init__.py
@@ -24,7 +24,7 @@ Adds a right click option on a cluster to look up album information using a sear
 
 Adds a right click option on an album or track to look up cover art for the selected album or title.
 '''
-PLUGIN_VERSION = '2.1.0'
+PLUGIN_VERSION = '2.1.1'
 PLUGIN_API_VERSIONS = ['2.0', '2.1', '2.2', '2.3']
 PLUGIN_LICENSE = "GPL-2.0"
 PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.txt"

--- a/plugins/search_engine_lookup/__init__.py
+++ b/plugins/search_engine_lookup/__init__.py
@@ -216,6 +216,10 @@ class SearchEngineLookupOptionsPage(OptionsPage):
         self.ui.pb_edit.clicked.connect(self.edit_provider)
         self.ui.pb_delete.clicked.connect(self.delete_provider)
         self.ui.pb_test.clicked.connect(self.test_provider)
+        self.ui.le_additional_words.textChanged.connect(self.additional_words_changed)
+
+    def additional_words_changed(self, text):
+        self.additional_words = text
 
     def load(self):
         # Settings for search engine providers


### PR DESCRIPTION
Previously, text entered into the 'Additional Search Words' field was not updating the internal setting variable. This meant changes were ignored during 'Save' and 'Test'.

This commit connects the textChanged signal of the input field to a handler that updates the self.additional_words variable immediately.

_Note: Description and code AI-written_

**Testing:**
- Ensured the changes are applied immediately when using "Test" button
- Ensured changes are only saved permanently when using "Make It So!" button and are reverted when using "Cancel"
- Ensured changes are picked up by "Search engine lookup" menu in cluster pane.