### PR TITLE
Fix invalid escape sequence for Python 3.12

### DIFF
--- a/plugins/classical_extras/__init__.py
+++ b/plugins/classical_extras/__init__.py
@@ -7506,10 +7506,10 @@ class PartLevels():
         # replace any punctuation or numbers, with a space (to remove any
         # inconsistent punctuation and numbering) - (?u) specifies the
         # re.UNICODE flag in sub
-        clean_parent = re.sub("(?u)[\W]", ' ', parent)
+        clean_parent = re.sub(r"(?u)[\W]", ' ', parent)
         # now allow the spaces to be filled with up to 2 non-letters
-        pattern_parent = clean_parent.replace(" ", "\W{0,2}")
-        pattern_parent = "(^|.*?\s)(\W*" + pattern_parent + "\W?)(.*)"
+        pattern_parent = clean_parent.replace(" ", r"\W{0,2}")
+        pattern_parent = r"(^|.*?\s)(\W*" + pattern_parent + r"\W?)(.*)"
         # (removed previous alternative pattern for extend=true, owing to catastrophic backtracking)
         write_log(
                 release_id,


### PR DESCRIPTION
### Summary
This PR fixes `SyntaxWarning` issues regarding invalid escape sequences that occur when running the plugin with Python 3.12.

### Changes
* Added the `r` (raw string) prefix to regular expression patterns in `plugins/classical_extras/__init__.py`.
* Specifically addressed the `\W` escape sequences that were causing syntax warnings.

### Related Issues
Fixes the Python 3.12 syntax errors mentioned in Issue #417.