### PR TITLE
Add plugin: Pseudo-Release Title Sort

### DIFF
--- a/plugins/pseudo-release-titlesort/pseudo-release-titlesort.py
+++ b/plugins/pseudo-release-titlesort/pseudo-release-titlesort.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 alydevs <aly@aly.pet>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Disclosure: Claude Sonnet 4.6 was used in the creation of pseudo-release-titlesort.py
+
+# Plugin metadata
+# =============================================================================
+PLUGIN_NAME = "Pseudo-Release Title Sort"
+PLUGIN_AUTHOR = "alydevs <aly@aly.pet>"
+PLUGIN_DESCRIPTION = """
+For releases matched to a Pseudo-Release on MusicBrainz, sets the **Title Sort**
+tag (`titlesort`) to the pseudo-release's own track title (e.g. a romanised
+English transliteration) rather than leaving it blank or using the original-
+language recording title.
+ 
+If the matched release is *not* a pseudo-release, the tag is left untouched.
+"""
+PLUGIN_VERSION = "1.0.4"
+PLUGIN_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
+PLUGIN_LICENSE = "GPL-2.0"
+PLUGIN_LICENSE_URL = "https://www.gnu.org/licenses/gpl-2.0.html"
+
+from picard import log
+from picard.metadata import register_track_metadata_processor
+
+
+def set_titlesort_from_pseudo_release(tagger, metadata, track, release):
+    """
+    Called by Picard for every track after it has populated `metadata` from MusicBrainz
+    """
+
+    # Only act on pseudo-releases.
+    # release["status"] is the <status> text, e.g. "Pseudo-Release".
+    try:
+        status = release.get("status", "")
+        if not status:
+            return
+        if status != "Pseudo-Release":
+            return
+    except Exception as e:
+        log.debug(str(e))
+        return
+
+    # Pull the track-level title if it differs from recording title
+    try:
+        title = track.get("title", "")
+        if not title:
+            log.warning("No title tag on track node")
+            return
+        if title == track.get("recording", {}).get("title",""):
+            log.info("Pseudo-release title matches recording title, skipping")
+            return
+        metadata["titlesort"] = title
+        log.info(f"Set titlesort to {title}")
+    except Exception as e:
+        log.warning(str(e))
+
+
+register_track_metadata_processor(set_titlesort_from_pseudo_release)


### PR DESCRIPTION
This plugin checks if a track title in a pseudo-release is different to the recording title, and applies the track title to the `titlesort` tag if so. This is useful in cases such as [Kessoku Band](https://musicbrainz.org/release/dc4e94fb-eeb9-46e1-ac40-98dbdd772b0e), where the English track names for this pseudo-release are shown in Picard, but the original kanji/kana script is used for titles. There are many instances of people wondering about this behaviour going back a couple years: https://redd.it/13fi3ur https://redd.it/1hud7g1 https://community.metabrainz.org/t/japanese-music-titles-into-their-english-names/557050/2

Before: English titles are shown in track list when adding pseudo-release, but tags only have Japanese titles, and there is no way to write English titles into tags
<img width="406" height="106" alt="image" src="https://github.com/user-attachments/assets/45da613c-f1b3-4231-b663-5a5a1e77f4c0" />
<img width="322" height="122" alt="image" src="https://github.com/user-attachments/assets/0e71ecb0-e4fe-48f9-9ed7-15a069e01c51" />

After: English titles are written to titlesort tag, this can be used in file naming script to set consistent filenames across a library. Original title is currently retained in track Title tag.
<img width="405" height="110" alt="image" src="https://github.com/user-attachments/assets/5af5a44e-5e28-4148-af95-d31abc225105" />
